### PR TITLE
Removing BouncyCastle dependency and using JCE standard library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,8 +68,5 @@ dependencies {
     compile "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64"
     compile "io.netty:netty-transport-native-kqueue:${nettyVersion}:osx-x86_64"
     compile "org.apache.commons:commons-lang3:3.7"
-
-    compile "org.bouncycastle:bcprov-jdk15on:1.59"
-    compile "org.bouncycastle:bcpkix-jdk15on:1.59"
 }
 

--- a/src/main/java/spiffe/provider/CertificateUtils.java
+++ b/src/main/java/spiffe/provider/CertificateUtils.java
@@ -1,8 +1,5 @@
 package spiffe.provider;
 
-import org.apache.commons.lang3.StringUtils;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-
 import java.io.ByteArrayInputStream;
 import java.security.*;
 import java.security.cert.*;
@@ -68,7 +65,7 @@ class CertificateUtils {
      * @throws InvalidKeySpecException
      */
     static PrivateKey generatePrivateKey(byte[] input) throws NoSuchAlgorithmException, InvalidKeySpecException {
-        KeyFactory keyFactory = KeyFactory.getInstance(PRIVATE_KEY_ALGORITHM, new BouncyCastleProvider());
+        KeyFactory keyFactory = KeyFactory.getInstance(PRIVATE_KEY_ALGORITHM);
         return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(input));
     }
 


### PR DESCRIPTION
Addressing issue: https://github.com/spiffe/java-spiffe/issues/7

Removing BouncyCastle dependency since the JCE standard library can be used to process the key material.

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>