### PR TITLE
Exposing SpiffeSVID to the library users

### DIFF
--- a/src/main/java/spiffe/provider/SpiffeIdManager.java
+++ b/src/main/java/spiffe/provider/SpiffeIdManager.java
@@ -17,7 +17,7 @@ import static java.util.Collections.EMPTY_SET;
  * It gets SVID updates asynchronously from the Workload API
  *
  */
-class SpiffeIdManager {
+public class SpiffeIdManager {
 
     private static final SpiffeIdManager INSTANCE = new SpiffeIdManager();
 
@@ -45,6 +45,10 @@ class SpiffeIdManager {
         guard = new FunctionalReadWriteLock();
         Fetcher<List<X509SVID>> svidFetcher = new X509SVIDFetcher();
         svidFetcher.registerListener(this::updateSVID);
+    }
+
+    public SpiffeSVID getSpiffeSVID() {
+        return guard.read(() -> spiffeSVID);
     }
 
     /**

--- a/src/main/java/spiffe/provider/SpiffeSVID.java
+++ b/src/main/java/spiffe/provider/SpiffeSVID.java
@@ -12,7 +12,7 @@ import java.util.logging.Logger;
  * Represents a SPIFFE Identity
  *
  */
-class SpiffeSVID {
+public class SpiffeSVID {
 
     private static final Logger LOGGER = Logger.getLogger(SpiffeSVID.class.getName());
 
@@ -51,19 +51,19 @@ class SpiffeSVID {
         }
     }
 
-    String getSpiffeID() {
+    public String getSpiffeID() {
         return spiffeID;
     }
 
-    X509Certificate getCertificate() {
+    public X509Certificate getCertificate() {
         return certificate;
     }
 
-    PrivateKey getPrivateKey() {
+    public PrivateKey getPrivateKey() {
         return privateKey;
     }
 
-    Set<X509Certificate> getBundle() {
+    public Set<X509Certificate> getBundle() {
         return bundle;
     }
 }


### PR DESCRIPTION
Exposing SpiffeSVID and SpiffeIdManager because it will be more convenient for the library users to have access to SpiffeSVID without resorting to the Java Security API, for example for logging purposes. 

Resolving issue: https://github.com/spiffe/java-spiffe/issues/6