### PR TITLE
Adding Federation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ In your `java.security` file:
 * replace `<n>` following the order of the `# List of Providers` in the master file. 
 
 * replace the value of the custom property `ssl.spiffe.accept` with the Spiffe IDs of the workloads that are allowed to connect.
+If the property is not present or if it's empty, any spiffe id will be authorized. 
 
 To pass your custom security properties file through the command line via system property when starting the JVM:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and receives the updates asynchronously from the Workload API. Using the termino
 this library provides a custom Security Provider that can be installed in the JVM. 
 
 It supports Federation. The TrustStore validates the peer's SVID using a set of Trusted CAs that includes the 
-Federated TrustDomains CAs bundles. These Federates CAs bundles come from the Workload API in the X509SVIDResponse.
+Federated TrustDomains CAs bundles. These Federated CAs bundles come from the Workload API in the X509SVIDResponse.
 
 ## SPIFFE Workload API Client Example
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'spiffe'
-version '0.1.0'
+version '0.2.0'
 
 
 buildscript {

--- a/src/main/java/spiffe/api/svid/X509SVIDFetcher.java
+++ b/src/main/java/spiffe/api/svid/X509SVIDFetcher.java
@@ -17,7 +17,7 @@ import java.util.logging.Logger;
  * Provides functionality to interact with a Workload API
  *
  */
-public final class X509SVIDFetcher implements Fetcher<List<X509SVID>> {
+public final class X509SVIDFetcher implements Fetcher<X509SVIDResponse> {
 
     private static final Logger LOGGER = Logger.getLogger(X509SVIDFetcher.class.getName());
 
@@ -58,19 +58,19 @@ public final class X509SVIDFetcher implements Fetcher<List<X509SVID>> {
     }
 
     /**
-     * Register the listener to receive the X509 SVIDS from the Workload API
+     * Register the listener to receive the X509SVIDResponse from the Workload API
      * In case there's an error in the connection with the Workload API,
      * it retries using a RetryHandler that implements a backoff policy
      *
      */
     @Override
-    public void registerListener(Consumer<List<X509SVID>> listener) {
+    public void registerListener(Consumer<X509SVIDResponse> listener) {
 
         StreamObserver<X509SVIDResponse> observer = new StreamObserver<X509SVIDResponse>() {
             @Override
             public void onNext(X509SVIDResponse value) {
                 LOGGER.log(Level.FINE, "New SVID received ");
-                listener.accept(value.getSvidsList());
+                listener.accept(value);
                 retryHandler.reset();
             }
 

--- a/src/main/java/spiffe/provider/SpiffeIdManager.java
+++ b/src/main/java/spiffe/provider/SpiffeIdManager.java
@@ -2,13 +2,14 @@ package spiffe.provider;
 
 import spiffe.api.svid.Fetcher;
 import spiffe.api.svid.Workload;
-import spiffe.api.svid.Workload.X509SVID;
 import spiffe.api.svid.X509SVIDFetcher;
 
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static java.util.Collections.EMPTY_SET;
 
@@ -21,6 +22,7 @@ import static java.util.Collections.EMPTY_SET;
 public class SpiffeIdManager {
 
     private static final SpiffeIdManager INSTANCE = new SpiffeIdManager();
+    private static final Logger LOGGER = Logger.getLogger(SpiffeIdManager.class.getName());
 
     static SpiffeIdManager getInstance() {
         return INSTANCE;
@@ -37,6 +39,11 @@ public class SpiffeIdManager {
     private final FunctionalReadWriteLock guard;
 
     /**
+     * Used to make the getters wait until there's a spiffeSVID initialized
+     */
+    private final CountDownLatch completedSpiffeSVIDUpdate = new CountDownLatch(1);
+
+    /**
      * Private Constructor
      *
      * Registers a certificate updater callback to get the SVID updates from the WorkloadAPI
@@ -49,6 +56,7 @@ public class SpiffeIdManager {
     }
 
     public SpiffeSVID getSpiffeSVID() {
+        awaitSpiffeSVID();
         return guard.read(() -> spiffeSVID);
     }
 
@@ -58,18 +66,32 @@ public class SpiffeIdManager {
      */
     private void updateSVID(Workload.X509SVIDResponse x509SVIDResponse) {
         guard.write(() -> spiffeSVID = new SpiffeSVID(x509SVIDResponse));
+        completedSpiffeSVIDUpdate.countDown();
+        LOGGER.log(Level.FINE, "Spiffe SVID has been updated ");
     }
 
-    X509Certificate getCertificate() {
+    public X509Certificate getCertificate() {
+        awaitSpiffeSVID();
         return guard.read(() -> spiffeSVID != null ? spiffeSVID.getCertificate() : null);
     }
 
-    PrivateKey getPrivateKey() {
+    public PrivateKey getPrivateKey() {
+        awaitSpiffeSVID();
         return guard.read(() -> spiffeSVID != null ? spiffeSVID.getPrivateKey() : null);
     }
 
     @SuppressWarnings("unchecked")
-    Set<X509Certificate> getTrustedCerts() {
+    public Set<X509Certificate> getTrustedCerts() {
+        awaitSpiffeSVID();
         return guard.read(() -> spiffeSVID != null ? spiffeSVID.getTrustedCerts() : EMPTY_SET);
+    }
+
+    private void awaitSpiffeSVID() {
+        try {
+            completedSpiffeSVIDUpdate.await();
+        } catch (InterruptedException e) {
+            LOGGER.info("Interrupted " + e.getMessage());
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/main/java/spiffe/provider/SpiffeSVID.java
+++ b/src/main/java/spiffe/provider/SpiffeSVID.java
@@ -1,9 +1,14 @@
 package spiffe.provider;
 
+import com.google.protobuf.ByteString;
 import spiffe.api.svid.Workload;
 
 import java.security.PrivateKey;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -20,35 +25,69 @@ public class SpiffeSVID {
      * The SPIFFE Identity String
      */
     private String spiffeID;
+
     /**
      * The SPIFFE Verifiable Identity Document
      */
     private X509Certificate certificate;
+
     /**
      * The Private Key associated to the Public Key of the certificate
      */
     private PrivateKey privateKey;
+
     /**
      *  The trust chain used as the set of CAs trusted certificates
      */
     private Set<X509Certificate> bundle;
 
     /**
+     *  The map of Federated Trust Domains and their bundles
+     */
+    private Map<String, Set<X509Certificate>> federatedBundles;
+
+    /**
+     *  All trusted CAs certs, including the Federated CAs
+     */
+    private Set<X509Certificate> trustedCerts;
+
+    /**
      * Constructor
      *
-     * @param x509SVID: Workload.X509SVID
+     * @param x509SVIDResponse: Workload.X509SVIDResponse
      *
      */
-    SpiffeSVID(Workload.X509SVID x509SVID) {
+    SpiffeSVID(Workload.X509SVIDResponse x509SVIDResponse) {
         try {
-            certificate = CertificateUtils.generateCertificate(x509SVID.getX509Svid().toByteArray());
-            bundle = CertificateUtils.generateCertificates(x509SVID.getBundle().toByteArray());
-            privateKey = CertificateUtils.generatePrivateKey(x509SVID.getX509SvidKey().toByteArray());
-            spiffeID = x509SVID.getSpiffeId();
+
+            Workload.X509SVID svid  = x509SVIDResponse.getSvidsList().get(0);
+
+            certificate = CertificateUtils.generateCertificate(svid.getX509Svid().toByteArray());
+            bundle = CertificateUtils.generateCertificates(svid.getBundle().toByteArray());
+            privateKey = CertificateUtils.generatePrivateKey(svid.getX509SvidKey().toByteArray());
+            spiffeID = svid.getSpiffeId();
+            federatedBundles = buildFederatedX509CertificatesMap(x509SVIDResponse.getFederatedBundlesMap());
+
+            trustedCerts = new HashSet<>();
+            trustedCerts.addAll(bundle);
+            federatedBundles.values().forEach(set -> trustedCerts.addAll(set));
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "SVID message could not be processed", e);
             throw new RuntimeException(e);
         }
+    }
+
+    private Map<String, Set<X509Certificate>> buildFederatedX509CertificatesMap(Map<String, ByteString> federatedBundlesMap) {
+        Map<String, Set<X509Certificate>> federatedCertificates = new HashMap<>();
+        federatedBundlesMap.forEach((trustDomain, cert) -> {
+            try {
+                federatedCertificates.put(trustDomain, CertificateUtils.generateCertificates(cert.toByteArray()));
+            } catch (CertificateException e) {
+                LOGGER.log(Level.SEVERE, "Federated Bundles couldn't be processed ", e);
+                throw new RuntimeException(e);
+            }
+        });
+        return federatedCertificates;
     }
 
     public String getSpiffeID() {
@@ -65,5 +104,13 @@ public class SpiffeSVID {
 
     public Set<X509Certificate> getBundle() {
         return bundle;
+    }
+
+    public Map<String, Set<X509Certificate>> getFederatedBundles() {
+        return federatedBundles;
+    }
+
+    public Set<X509Certificate> getTrustedCerts() {
+        return trustedCerts;
     }
 }

--- a/src/main/proto/workload.proto
+++ b/src/main/proto/workload.proto
@@ -7,7 +7,7 @@ message X509SVIDRequest {  }
 
 // The X509SVIDResponse message carries a set of X.509 SVIDs and their
 // associated information. It also carries a set of global CRLs, and a
-// TTL to inform the svid when it should check back next.
+// TTL to inform the workload when it should check back next.
 message X509SVIDResponse {
     // A list of X509SVID messages, each of which includes a single
     // SPIFFE Verifiable Identity Document, along with its private key
@@ -18,19 +18,19 @@ message X509SVIDResponse {
     repeated bytes crl = 2;
 
     // CA certificate bundles belonging to foreign Trust Domains that the
-    // svid should trust, keyed by the SPIFFE ID of the foreign
+    // workload should trust, keyed by the SPIFFE ID of the foreign
     // domain. Bundles are ASN.1 DER encoded.
     map<string, bytes> federated_bundles = 3;
 }
 
-// The X509SVID message carries a single WorkloadAPIClient and all associated
+// The X509SVID message carries a single SVID and all associated
 // information, including CA bundles.
 message X509SVID {
-    // The SPIFFE ID of the WorkloadAPIClient in this entry
+    // The SPIFFE ID of the SVID in this entry
     string spiffe_id = 1;
 
     // ASN.1 DER encoded certificate chain. MAY include intermediates,
-    // the leaf certificate (or WorkloadAPIClient itself) MUST come first.
+    // the leaf certificate (or SVID itself) MUST come first.
     bytes x509_svid = 2;
 
     // ASN.1 DER encoded PKCS#8 private key. MUST be unencrypted.
@@ -40,11 +40,14 @@ message X509SVID {
     // ASN.1 DER encoded
     bytes bundle = 4;
 
+    // List of trust domains the SVID federates with, which corresponds to
+    // keys in the federated_bundles map in the X509SVIDResponse message.
+    repeated string federates_with = 5;
 }
 
 service SpiffeWorkloadAPI {
-    // X.509-WorkloadAPIClient Profile
-    // Fetch all SPIFFE identities the svid is entitled to, as
+    // X.509-SVID Profile
+    // Fetch all SPIFFE identities the workload is entitled to, as
     // well as related information like trust bundles and CRLs. As
     // this information changes, subsequent messages will be sent.
     rpc FetchX509SVID(X509SVIDRequest) returns (stream X509SVIDResponse);


### PR DESCRIPTION
This PR includes the following changes:

-  _workload.proto_ updated to the last version
-  updated _SpiffeSVID_, _X509SVIDFetcher_ and _SpiffeIdManager_ to read the Federated
Bundles and use them in the TrustStore _checkClient_ validation method.