### PR TITLE
Bump grpc versions to current

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,9 @@ buildscript {
 }
 
 ext {
-    grpcVersion = '1.17.1'
-    nettyVersion = '4.1.32.Final'
-    protobufProtocVersion = '3.6.1'
+    grpcVersion = '1.21.0'
+    nettyVersion = '4.1.33.Final'
+    protobufProtocVersion = '3.7.1'
     apacheCommonsVersion = '3.8.1'
 }
 
@@ -62,8 +62,8 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
     implementation group: 'io.grpc', name: 'grpc-netty', version: "${grpcVersion}"
@@ -72,5 +72,6 @@ dependencies {
     implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: "${nettyVersion}", classifier: 'linux-x86_64'
     implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: "${nettyVersion}", classifier: 'osx-x86_64'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${apacheCommonsVersion}"
+    compileOnly group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
 }
 


### PR DESCRIPTION
Bump the grpc library to the current version, along with netty and protoc to match.
Add the javax.annotation dependency to allow building with Java > 1.8