### PR TITLE
Log throwable when StreamObserver#onError is triggered

### DIFF
--- a/src/main/java/spiffe/api/svid/X509SVIDFetcher.java
+++ b/src/main/java/spiffe/api/svid/X509SVIDFetcher.java
@@ -76,7 +76,7 @@ public final class X509SVIDFetcher implements Fetcher<X509SVIDResponse> {
 
             @Override
             public void onError(Throwable t) {
-                LOGGER.log(Level.SEVERE, String.format("Could not get SVID \n %s", t.getMessage()));
+                LOGGER.log(Level.SEVERE, String.format("Could not get SVID \n %s", t.getMessage()), t);
                 if (isRetryableError(t)) {
                     retryHandler.scheduleRetry(() -> registerListener(listener));
                 }


### PR DESCRIPTION
Log throwable when StreamObserver#onError is triggered so that actual cause won't get lost.