### PR TITLE
Avoid netty warning by setting unknown channel option to null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'spiffe'
-version '0.5.0'
+version '0.5.1'
 
 buildscript {
     repositories {

--- a/src/main/java/spiffe/api/svid/SpiffeEndpointChannelBuilder.java
+++ b/src/main/java/spiffe/api/svid/SpiffeEndpointChannelBuilder.java
@@ -108,12 +108,12 @@ class SpiffeEndpointChannelBuilder {
         checkNotNull(channelBuilder, "Channel builder is Null");
         if (SystemUtils.IS_OS_LINUX) {
             channelBuilder.eventLoopGroup(new EpollEventLoopGroup())
-                          // avoid Unknown channel option 'SO_KEEPALIVE'
+                    // avoid Unknown channel option 'SO_KEEPALIVE'
                     .withOption(ChannelOption.SO_KEEPALIVE, null)
                     .channelType(EpollDomainSocketChannel.class);
         } else if (SystemUtils.IS_OS_MAC) {
             channelBuilder.eventLoopGroup(new KQueueEventLoopGroup())
-                     .withOption(ChannelOption.SO_KEEPALIVE, null)
+                    .withOption(ChannelOption.SO_KEEPALIVE, null)
                     .channelType(KQueueDomainSocketChannel.class);
         } else {
             channelBuilder.eventLoopGroup(new NioEventLoopGroup());

--- a/src/main/java/spiffe/api/svid/SpiffeEndpointChannelBuilder.java
+++ b/src/main/java/spiffe/api/svid/SpiffeEndpointChannelBuilder.java
@@ -3,6 +3,7 @@ package spiffe.api.svid;
 import io.grpc.*;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.kqueue.KQueueDomainSocketChannel;
@@ -107,6 +108,8 @@ class SpiffeEndpointChannelBuilder {
         checkNotNull(channelBuilder, "Channel builder is Null");
         if (SystemUtils.IS_OS_LINUX) {
             channelBuilder.eventLoopGroup(new EpollEventLoopGroup())
+                          // avoid Unknown channel option 'SO_KEEPALIVE'
+                          .withOption(ChannelOption.SO_KEEPALIVE, null)
                           .channelType(EpollDomainSocketChannel.class);
         } else if (SystemUtils.IS_OS_MAC) {
             channelBuilder.eventLoopGroup(new KQueueEventLoopGroup())

--- a/src/main/java/spiffe/api/svid/SpiffeEndpointChannelBuilder.java
+++ b/src/main/java/spiffe/api/svid/SpiffeEndpointChannelBuilder.java
@@ -109,11 +109,12 @@ class SpiffeEndpointChannelBuilder {
         if (SystemUtils.IS_OS_LINUX) {
             channelBuilder.eventLoopGroup(new EpollEventLoopGroup())
                           // avoid Unknown channel option 'SO_KEEPALIVE'
-                          .withOption(ChannelOption.SO_KEEPALIVE, null)
-                          .channelType(EpollDomainSocketChannel.class);
+                    .withOption(ChannelOption.SO_KEEPALIVE, null)
+                    .channelType(EpollDomainSocketChannel.class);
         } else if (SystemUtils.IS_OS_MAC) {
             channelBuilder.eventLoopGroup(new KQueueEventLoopGroup())
-                          .channelType(KQueueDomainSocketChannel.class);
+                     .withOption(ChannelOption.SO_KEEPALIVE, null)
+                    .channelType(KQueueDomainSocketChannel.class);
         } else {
             channelBuilder.eventLoopGroup(new NioEventLoopGroup());
         }


### PR DESCRIPTION
Keep-alive option is not set for Unix Domain Socket connections. Setting this option causes warnings in the log and the option has no effect on the channel.

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>