### PR TITLE
Updating README and gradle tasks for publishing artifacts to maven central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# JAVA-SPIFFE library
+# Java SPIFFE Library
 
 <a href='https://travis-ci.org/spiffe/java-spiffe.svg?branch=master'><img src='https://travis-ci.org/spiffe/java-spiffe.svg?branch=master'></a>
 [![Coverage Status](https://coveralls.io/repos/github/spiffe/java-spiffe/badge.svg)](https://coveralls.io/github/spiffe/java-spiffe?branch=master)
-
-**Supports Java 8+**
 
 ## Overview
 
@@ -16,12 +14,56 @@ peer's certificate and SPIFFE ID verification.
 
 This library contains three modules:
 
-[java-spiffe-core](java-spiffe-core/README.md): Core functionality to interact with the Workload API, and to process and validate 
+* [java-spiffe-core](java-spiffe-core/README.md): Core functionality to interact with the Workload API, and to process and validate 
 X.509 and JWT SVIDs and bundles.
 
-[java-spiffe-provider](java-spiffe-provider/README.md): Java Provider implementation.
+* [java-spiffe-provider](java-spiffe-provider/README.md): Java Provider implementation.
 
-[java-spiffe-helper](java-spiffe-helper/README.md): Helper to store X.509 SVIDs and Bundles in Java Keystores in disk.
+* [java-spiffe-helper](java-spiffe-helper/README.md): Helper to store X.509 SVIDs and Bundles in Java Keystores in disk.
+
+**Supports Java 8+**
+
+Download
+--------
+
+The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.6.0). 
+
+The dependencies can be added to `pom.xml`:
+```xml
+<dependency>
+  <groupId>io.spiffe</groupId>
+  <artifactId>java-spiffe-core</artifactId>
+  <version>0.6.0</version>
+</dependency>
+<dependency>
+  <groupId>io.spiffe</groupId>
+  <artifactId>java-spiffe-provider</artifactId>
+  <version>0.6.0</version>
+</dependency>
+```
+
+Using Gradle:
+```gradle
+implementation 'io.spiffe:java-spiffe-core:0.6.0'
+implementation 'io.spiffe:java-spiffe-provider:0.6.0'
+```
+
+### MacOS Support
+
+Add to your `pom.xml`:
+```xml
+<dependency>
+  <groupId>io.spiffe</groupId>
+  <artifactId>grpc-netty-macos</artifactId>
+  <version>0.6.0</version>
+  <scope>runtime</scope>
+</dependency>
+```
+
+Using Gradle:
+```gradle
+runtimeOnly 'io.spiffe:grpc-netty-macos:0.6.0'
+```
 
 ### Build the JARs
 
@@ -34,7 +76,13 @@ On Linux or MacOS, run:
 
 All `jar` files are placed in `build/libs` folder.  
 
-Based on the OS, the jars will have a different classifier at the end of the jars names:
+#### Jars that include all dependencies 
+
+For the module [java-spiffe-provider](java-spiffe-provider), a fat jar is generated with the classifier `-all-[os-classifier]`.
+
+Fhe module [java-spiffe-helper](java-spiffe-helper), a fat jar is generated with the classifier `[os-classifier]`
+
+Based on the OS where the build is run, the `[os-classifier]` will be:
 
 * `-linux-x86_64` for Linux
-* `-osx-x86_64` for Mac OS
+* `-osx-x86_64` for MacOS

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.github.kt3k.coveralls' version '2.10.1'
+    id 'com.google.osdetector' version '1.6.2'
 }
 
 allprojects {
@@ -19,15 +20,11 @@ subprojects {
         mockitoVersion = '3.3.3'
         lombokVersion = '1.18.12'
         nimbusVersion = '8.19'
-
-        if (gradle.ext.isMacOs) {
-            osClassifier = "osx-x86_64"
-        } else {
-            osClassifier = "linux-x86_64"
-        }
     }
 
     apply plugin: 'java-library'
+    apply plugin: 'maven-publish'
+    apply plugin: 'signing'
 
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -37,13 +34,64 @@ subprojects {
         withSourcesJar()
     }
 
-    jar {
-        archiveClassifier = osClassifier
-    }
-
     javadoc {
         exclude "**/grpc/**"
         exclude "**/internal/**"
+    }
+
+    publishing {
+        repositories {
+            maven {
+                credentials {
+                    username = project.properties["mavenDeployUser"]
+                    password = project.properties["mavenDeployPassword"]
+                }
+                url = project.properties["mavenDeployUrl"]
+            }
+        }
+
+        publications {
+            mavenJava(MavenPublication) {
+                groupId project.group
+                version "${project.version}"
+                from components.java
+
+                pom {
+                    name = project.name
+                    artifactId = project.name
+                    url = 'https://github.com/spiffe/java-spiffe'
+                    afterEvaluate {
+                        // description is not available until evaluated.
+                        description = project.description
+                    }
+
+                    scm {
+                        connection = 'scm:git:https://github.com/spiffe/java-spiffe.git'
+                        developerConnection = 'scm:git:git@github.com:spiffe/java-spiffe.git'
+                        url = 'https://github.com/spiffe/java-spiffe'
+                    }
+
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = 'maxlambrecht'
+                            name = 'Max Lambrecht'
+                            email = 'maxlambrecht@gmail.com'
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    signing {
+        sign publishing.publications.mavenJava
     }
 
     dependencies {
@@ -129,4 +177,3 @@ task clean {
     dependsOn subprojects.clean
     delete "$buildDir"
 }
-

--- a/java-spiffe-core/build.gradle
+++ b/java-spiffe-core/build.gradle
@@ -8,6 +8,8 @@ buildscript {
     }
 }
 
+description = "Core functionality to fetch, process and validate X.509 and JWT SVIDs and Bundles from the Workload API."
+
 apply plugin: 'com.google.protobuf'
 apply plugin: 'java-test-fixtures'
 
@@ -37,16 +39,18 @@ protobuf {
 }
 
 dependencies {
-    if (gradle.ext.isMacOs) {
-        implementation (project(':java-spiffe-core:grpc-netty-macos'))
+    if (gradle.ext.isMacOsX) {
+        compileOnly(project('grpc-netty-macos'))
+        testImplementation(project('grpc-netty-macos'))
     } else {
-        implementation (project(':java-spiffe-core:grpc-netty-linux'))
+        compileOnly(project('grpc-netty-linux'))
+        testImplementation(project('grpc-netty-linux'))
     }
 
     implementation group: 'io.grpc', name: 'grpc-protobuf', version: "${grpcVersion}"
     implementation group: 'io.grpc', name: 'grpc-stub', version: "${grpcVersion}"
     testImplementation group: 'io.grpc', name: 'grpc-testing', version: "${grpcVersion}"
-    compileOnly group: 'org.apache.tomcat', name:'annotations-api', version: '6.0.53' // necessary for Java 9+
+    compileOnly group: 'org.apache.tomcat', name: 'annotations-api', version: '6.0.53' // necessary for Java 9+
 
     // library for processing JWT tokens and JOSE JWK bundles
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: "${nimbusVersion}"

--- a/java-spiffe-core/grpc-netty-linux/build.gradle
+++ b/java-spiffe-core/grpc-netty-linux/build.gradle
@@ -1,3 +1,5 @@
+description = "Java SPIFFE Library GRPC-Netty Linux support module"
+
 dependencies {
     implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: "${grpcVersion}"
 }

--- a/java-spiffe-core/grpc-netty-macos/build.gradle
+++ b/java-spiffe-core/grpc-netty-macos/build.gradle
@@ -1,3 +1,5 @@
+description = "Java SPIFFE Library GRPC-Netty MacOS module"
+
 dependencies {
     implementation group: 'io.grpc', name: 'grpc-netty', version: "${grpcVersion}"
     implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.50.Final', classifier: 'osx-x86_64'

--- a/java-spiffe-helper/build.gradle
+++ b/java-spiffe-helper/build.gradle
@@ -2,19 +2,29 @@ plugins {
     id "com.github.johnrengelman.shadow" version "5.2.0"
 }
 
+description = "Java SPIFFE Library Helper module to store X.509 SVIDs and Bundles in a Java KeyStore in disk"
+
 apply plugin: 'com.github.johnrengelman.shadow'
 
 assemble.dependsOn shadowJar
 
 shadowJar {
-    archiveClassifier = osClassifier
+    archiveClassifier = osdetector.classifier
     manifest {
         attributes 'Main-Class': 'io.spiffe.helper.cli.Runner'
     }
 }
 
 dependencies {
-    api (project(':java-spiffe-core'))
+    api(project(':java-spiffe-core'))
+
+    // runtimeOnly grpc-netty dependency module will be included in the shadowJar
+    if (gradle.ext.isMacOsX) {
+        runtimeOnly(project(':java-spiffe-core:grpc-netty-macos'))
+    } else {
+        runtimeOnly(project(':java-spiffe-core:grpc-netty-linux'))
+    }
+
     implementation group: 'commons-cli', name: 'commons-cli', version: '1.4'
 
     testImplementation(testFixtures(project(":java-spiffe-core")))

--- a/java-spiffe-provider/README.md
+++ b/java-spiffe-provider/README.md
@@ -11,7 +11,7 @@ Security property defined in the `java.security` file containing the list of SPI
 will trust for TLS connections:
 
 ```
-    X509Source source = X509Source.newSource();
+    X509Source source = DefaultX509Source.newSource();
     SslContextOptions options = SslContextOptions
             .builder()
             .x509Source(source)
@@ -31,7 +31,7 @@ Alternatively, a different Workload API address can be used by passing it to the
             .spiffeSocketPath("unix:/tmp/agent.sock")
             .build();
 
-    X509Source x509Source = X509Source.newSource(sourceOptions);
+    X509Source x509Source = DefaultX509Source.newSource(sourceOptions);
 
     Supplier<Set<SpiffeId>> spiffeIdSetSupplier = () -> Collections.singleton(SpiffeId.parse("spiffe://example.org/test"));
 
@@ -183,7 +183,7 @@ with a [X509Source instance](../java-spiffe-core/README.md#x509-source).
 
 ```
     // create a new X.509 source using the default socket endpoint address
-    X509Source x509Source = X509Source.newSource();
+    X509Source x509Source = DefaultX509Source.newSource();
     KeyManager keyManager = new SpiffeKeyManager(x509Source);
 
     // TrustManager gets the X509Source and the supplier of the Set of accepted SPIFFE IDs.
@@ -206,7 +206,7 @@ For the client, a `ManagedChannel` would be created using the `SpiffeKeyManager`
 the GRPC SSL context, analogous to the config for the Server:
 
 ``` 
-    X509Source x509Source = X509Source.newSource();
+    X509Source x509Source = DefaultX509Source.newSource();
     KeyManager keyManager = new SpiffeKeyManager(x509Source);
     TrustManager trustManager = new SpiffeTrustManager(x509Source, () -> SpiffeIdUtils.toSetOfSpiffeIds("spiffe://example.org/workload-server", ','));
 

--- a/java-spiffe-provider/build.gradle
+++ b/java-spiffe-provider/build.gradle
@@ -1,18 +1,27 @@
-
 plugins {
     id "com.github.johnrengelman.shadow" version "5.2.0"
 }
+
+description = "Java Security Provider implementation supporting X.509-SVIDs and methods for " +
+              "creating SSLContexts that are backed by the Workload API."
 
 apply plugin: 'com.github.johnrengelman.shadow'
 
 assemble.dependsOn shadowJar
 
 shadowJar {
-    archiveClassifier = "all-".concat(osClassifier)
+    archiveClassifier = "all-".concat(osdetector.classifier)
 }
 
 dependencies {
     api(project(":java-spiffe-core"))
+
+    // runtimeOnly grpc-netty dependency module will be included in the shadowJar
+    if (gradle.ext.isMacOsX) {
+        runtimeOnly(project(':java-spiffe-core:grpc-netty-macos'))
+    } else {
+        runtimeOnly(project(':java-spiffe-core:grpc-netty-linux'))
+    }
 
     testImplementation(testFixtures(project(":java-spiffe-core")))
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,14 +1,9 @@
-import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.internal.os.OperatingSystem
+gradle.ext.isMacOsX = OperatingSystem.current().isMacOsX()
 
 rootProject.name = 'java-spiffe'
 include 'java-spiffe-core'
 include 'java-spiffe-provider'
 include 'java-spiffe-helper'
-
-gradle.ext.isMacOs = Os.isFamily(Os.FAMILY_MAC)
-if (gradle.ext.isMacOs) {
-    include 'java-spiffe-core:grpc-netty-macos'
-} else {
-    include 'java-spiffe-core:grpc-netty-linux'
-}
-
+include 'java-spiffe-core:grpc-netty-linux'
+include 'java-spiffe-core:grpc-netty-macos'


### PR DESCRIPTION
This PR adds the tasks to create and publish the maven publications (metadata, pom, signed artifacts).
It adds the instructions to the README to fetch the artifacts from maven central defining maven pom or gradle dependencies.

The artifacts for version 0.6.0 have already been published and are available to be downloaded. 

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>