### PR TITLE
Fix jwt-svid audience validation. Update dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,26 @@ X.509 and JWT SVIDs and bundles.
 Download
 --------
 
-The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.6.0). 
+The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.6.1). 
 
 The dependencies can be added to `pom.xml`:
 ```xml
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-core</artifactId>
-  <version>0.6.0</version>
+  <version>0.6.1</version>
 </dependency>
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-provider</artifactId>
-  <version>0.6.0</version>
+  <version>0.6.1</version>
 </dependency>
 ```
 
 Using Gradle:
 ```gradle
-implementation 'io.spiffe:java-spiffe-core:0.6.0'
-implementation 'io.spiffe:java-spiffe-provider:0.6.0'
+implementation 'io.spiffe:java-spiffe-core:0.6.1'
+implementation 'io.spiffe:java-spiffe-provider:0.6.1'
 ```
 
 ### MacOS Support
@@ -55,14 +55,14 @@ Add to your `pom.xml`:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>grpc-netty-macos</artifactId>
-  <version>0.6.0</version>
+  <version>0.6.1</version>
   <scope>runtime</scope>
 </dependency>
 ```
 
 Using Gradle:
 ```gradle
-runtimeOnly 'io.spiffe:grpc-netty-macos:0.6.0'
+runtimeOnly 'io.spiffe:grpc-netty-macos:0.6.1'
 ```
 
 ### Build the JARs

--- a/build.gradle
+++ b/build.gradle
@@ -12,14 +12,14 @@ allprojects {
 
 subprojects {
     group = 'io.spiffe'
-    version = '0.6.0'
+    version = '0.6.1'
 
     ext {
-        grpcVersion = '1.30.2'
+        grpcVersion = '1.31.1'
         jupiterVersion = '5.6.2'
-        mockitoVersion = '3.3.3'
+        mockitoVersion = '3.5.2'
         lombokVersion = '1.18.12'
-        nimbusVersion = '8.19'
+        nimbusVersion = '8.20'
     }
 
     apply plugin: 'java-library'
@@ -95,8 +95,8 @@ subprojects {
     }
 
     dependencies {
-        implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
-        implementation group: 'commons-validator', name: 'commons-validator', version: "1.6"
+        implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
+        implementation group: 'commons-validator', name: 'commons-validator', version: "1.7"
 
         testCompileOnly group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: "${jupiterVersion}"
         testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: "${jupiterVersion}"

--- a/java-spiffe-core/build.gradle
+++ b/java-spiffe-core/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     testFixturesImplementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: "${nimbusVersion}"
 
     // using bouncy castle for generating X.509 certs for testing purposes
-    testFixturesImplementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.65'
-    testFixturesImplementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
+    testFixturesImplementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.66'
+    testFixturesImplementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
 }
 

--- a/java-spiffe-core/grpc-netty-macos/build.gradle
+++ b/java-spiffe-core/grpc-netty-macos/build.gradle
@@ -2,7 +2,7 @@ description = "Java SPIFFE Library GRPC-Netty MacOS module"
 
 dependencies {
     implementation group: 'io.grpc', name: 'grpc-netty', version: "${grpcVersion}"
-    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.50.Final', classifier: 'osx-x86_64'
+    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.51.Final', classifier: 'osx-x86_64'
 }
 
 jar {

--- a/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
@@ -278,11 +278,10 @@ public class JwtSvid {
 
     }
 
-    private static void validateAudience(final List<String> audClaim, final Set<String> expectedAudience) throws JwtSvidException {
-        for (String aud : audClaim) {
-            if (!expectedAudience.contains(aud)) {
-                throw new JwtSvidException(String.format("expected audience in %s (audience=%s)", expectedAudience, audClaim));
-            }
+    // expected audiences must be a subset of the audience claim in the token
+    private static void validateAudience(final List<String> audClaim, final Set<String> expectedAudiences) throws JwtSvidException {
+        if (!audClaim.containsAll(expectedAudiences)) {
+            throw new JwtSvidException(String.format("expected audience in %s (audience=%s)", expectedAudiences, audClaim));
         }
     }
 }

--- a/java-spiffe-helper/README.md
+++ b/java-spiffe-helper/README.md
@@ -10,11 +10,11 @@ The Helper automatically gets the SVID updates and stores them in the KeyStore a
 
 On Linux:
 
-`java -jar java-spiffe-helper-0.6.0-linux-x86_64.jar -c helper.conf`
+`java -jar java-spiffe-helper-0.6.1-linux-x86_64.jar -c helper.conf`
 
 On Mac OS:
 
-`java -jar java-spiffe-helper-0.6.0-osx-x86_64.jar -c helper.conf`
+`java -jar java-spiffe-helper-0.6.1-osx-x86_64.jar -c helper.conf`
 
 (The jar can be found in `build/libs`, after running the gradle build)
 


### PR DESCRIPTION
Fix jwt-svid audience validation.

Bump version to 0.6.1
Upgrade gprc-java dependency to 1.31.1
Upgrade other dependencies.

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>