### PR TITLE
Configuration, validation and logging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,39 @@ X.509 and JWT SVIDs and bundles.
 Download
 --------
 
-The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.6.1). 
+The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.6.2). 
 
-The dependencies can be added to `pom.xml`:
+The dependencies can be added to `pom.xml`
+
+To import the `java-spiffe-provider` component: 
+```xml
+<dependency>
+  <groupId>io.spiffe</groupId>
+  <artifactId>java-spiffe-provider</artifactId>
+  <version>0.6.2</version>
+</dependency>
+```
+The `java-spiffe-provider` component imports the `java-spiffe-core` component.
+
+To just import the `java-spiffe-core` component:
 ```xml
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-core</artifactId>
-  <version>0.6.1</version>
-</dependency>
-<dependency>
-  <groupId>io.spiffe</groupId>
-  <artifactId>java-spiffe-provider</artifactId>
-  <version>0.6.1</version>
+  <version>0.6.2</version>
 </dependency>
 ```
 
 Using Gradle:
+
+Import `java-spiffe-provider`:
 ```gradle
-implementation 'io.spiffe:java-spiffe-core:0.6.1'
-implementation 'io.spiffe:java-spiffe-provider:0.6.1'
+implementation group: 'io.spiffe', name: 'java-spiffe-provider', version: '0.6.2'
+```
+
+Import `java-spiffe-core`:
+```gradle
+implementation group: 'io.spiffe', name: 'java-spiffe-core', version: '0.6.2'
 ```
 
 ### MacOS Support
@@ -55,14 +68,14 @@ Add to your `pom.xml`:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>grpc-netty-macos</artifactId>
-  <version>0.6.1</version>
+  <version>0.6.2</version>
   <scope>runtime</scope>
 </dependency>
 ```
 
 Using Gradle:
 ```gradle
-runtimeOnly 'io.spiffe:grpc-netty-macos:0.6.1'
+runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos', version: '0.6.2'
 ```
 
 ### Build the JARs

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ allprojects {
 
 subprojects {
     group = 'io.spiffe'
-    version = '0.6.1'
+    version = '0.6.2'
 
     ext {
         grpcVersion = '1.31.1'

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/DefaultX509Source.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/DefaultX509Source.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import static io.spiffe.workloadapi.internal.ThreadUtils.await;
 
@@ -139,9 +140,8 @@ public final class DefaultX509Source implements X509Source {
      * Returns the X.509 bundle for a given trust domain.
      *
      * @return an instance of a {@link X509Bundle}
-     *
      * @throws BundleNotFoundException is there is no bundle for the trust domain provided
-     * @throws IllegalStateException if the source is closed
+     * @throws IllegalStateException   if the source is closed
      */
     @Override
     public X509Bundle getBundleForTrustDomain(@NonNull final TrustDomain trustDomain) throws BundleNotFoundException {
@@ -200,7 +200,8 @@ public final class DefaultX509Source implements X509Source {
         workloadApiClient.watchX509Context(new Watcher<X509Context>() {
             @Override
             public void onUpdate(final X509Context update) {
-                log.log(Level.INFO, "Received X509Context update");
+                String spiffeIds = update.getX509Svids().stream().map(s -> s.getSpiffeId().toString()).collect(Collectors.joining(", "));
+                log.log(Level.INFO, String.format("Received X509Context update: %s", spiffeIds));
                 setX509Context(update);
                 done.countDown();
             }

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidValidatorTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidValidatorTest.java
@@ -81,7 +81,7 @@ public class X509SvidValidatorTest {
     }
 
     @Test
-    void checkSpiffeId_givenASpiffeIdInTheListOfAcceptedIds_doesntThrowException() throws IOException, CertificateException, URISyntaxException {
+    void verifySpiffeId_givenASpiffeIdInTheListOfAcceptedIds_doesntThrowException() throws IOException, CertificateException, URISyntaxException {
         val spiffeId1 = SpiffeId.parse("spiffe://example.org/test");
         val spiffeId2 = SpiffeId.parse("spiffe://example.org/test2");
 
@@ -91,7 +91,7 @@ public class X509SvidValidatorTest {
     }
 
     @Test
-    void checkSpiffeId_givenASpiffeIdNotInTheListOfAcceptedIds_throwsCertificateException() throws IOException, CertificateException, URISyntaxException {
+    void verifySpiffeId_givenASpiffeIdNotInTheListOfAcceptedIds_throwsCertificateException() throws IOException, CertificateException, URISyntaxException {
         val spiffeId1 = SpiffeId.parse("spiffe://example.org/other1");
         val spiffeId2 = SpiffeId.parse("spiffe://example.org/other2");
         val spiffeIdSet = Sets.newHashSet(spiffeId1, spiffeId2);
@@ -102,6 +102,17 @@ public class X509SvidValidatorTest {
         } catch (CertificateException e) {
             assertEquals("SPIFFE ID spiffe://example.org/test in X.509 certificate is not accepted", e.getMessage());
         }
+    }
+
+    @Test
+    void verifySpiffeId_givenAnEmptySupplier_throwsCertificateException() {
+        try {
+            X509SvidValidator.verifySpiffeId(leaf.getCertificate(), Collections::emptySet);
+            fail("Should have thrown CertificateException");
+        } catch (CertificateException e) {
+            assertEquals("The supplier of accepted SPIFFE IDs supplied an empty set", e.getMessage());
+        }
+
     }
 
     @Test

--- a/java-spiffe-helper/README.md
+++ b/java-spiffe-helper/README.md
@@ -10,11 +10,11 @@ The Helper automatically gets the SVID updates and stores them in the KeyStore a
 
 On Linux:
 
-`java -jar java-spiffe-helper-0.6.1-linux-x86_64.jar -c helper.conf`
+`java -jar java-spiffe-helper-0.6.2-linux-x86_64.jar -c helper.conf`
 
 On Mac OS:
 
-`java -jar java-spiffe-helper-0.6.1-osx-x86_64.jar -c helper.conf`
+`java -jar java-spiffe-helper-0.6.2-osx-x86_64.jar -c helper.conf`
 
 (The jar can be found in `build/libs`, after running the gradle build)
 

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeSslContextFactory.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeSslContextFactory.java
@@ -4,7 +4,6 @@ import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.workloadapi.DefaultX509Source;
 import io.spiffe.workloadapi.X509Source;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.Setter;
@@ -47,6 +46,11 @@ public final class SpiffeSslContextFactory {
 
         if (options.x509Source == null) {
             throw new IllegalArgumentException("x509Source option cannot be null, an X.509 Source must be provided");
+        }
+
+        if (!options.acceptAnySpiffeId && options.acceptedSpiffeIdsSupplier == null) {
+            throw new IllegalArgumentException("SSL context should be configured either with a Supplier " +
+                    "of accepted SPIFFE IDs or with acceptAnySpiffeId=true");
         }
 
         val sslContext = newSslContext(options);
@@ -109,7 +113,6 @@ public final class SpiffeSslContextFactory {
         @Setter(AccessLevel.NONE)
         private boolean acceptAnySpiffeId;
 
-        @Builder
         public SslContextOptions(
                 final String sslProtocol,
                 final X509Source x509Source,
@@ -119,6 +122,44 @@ public final class SpiffeSslContextFactory {
             this.acceptedSpiffeIdsSupplier = acceptedSpiffeIdsSupplier;
             this.sslProtocol = sslProtocol;
             this.acceptAnySpiffeId = acceptAnySpiffeId;
+        }
+
+        public static SslContextOptionsBuilder builder() {
+            return new SslContextOptionsBuilder();
+        }
+
+        public static class SslContextOptionsBuilder {
+            private String sslProtocol;
+            private X509Source x509Source;
+            private Supplier<Set<SpiffeId>> acceptedSpiffeIdsSupplier;
+            private boolean acceptAnySpiffeId;
+
+            SslContextOptionsBuilder() {
+            }
+
+            public SslContextOptionsBuilder sslProtocol(String sslProtocol) {
+                this.sslProtocol = sslProtocol;
+                return this;
+            }
+
+            public SslContextOptionsBuilder x509Source(X509Source x509Source) {
+                this.x509Source = x509Source;
+                return this;
+            }
+
+            public SslContextOptionsBuilder acceptedSpiffeIdsSupplier(Supplier<Set<SpiffeId>> acceptedSpiffeIdsSupplier) {
+                this.acceptedSpiffeIdsSupplier = acceptedSpiffeIdsSupplier;
+                return this;
+            }
+
+            public SslContextOptionsBuilder acceptAnySpiffeId() {
+                this.acceptAnySpiffeId = true;
+                return this;
+            }
+
+            public SslContextOptions build() {
+                return new SslContextOptions(sslProtocol, x509Source, acceptedSpiffeIdsSupplier, acceptAnySpiffeId);
+            }
         }
     }
 }

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeTrustManager.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeTrustManager.java
@@ -51,15 +51,15 @@ public final class SpiffeTrustManager extends X509ExtendedTrustManager {
      * <p>
      * Creates a {@link SpiffeTrustManager} with an X.509 bundle source used to provide the trusted bundles,
      * and a flag to indicate that any SPIFFE ID will be accepted.
+     * <p>
+     * Any SPIFFE ID will be accepted during peer SVID validation.
      *
      * @param x509BundleSource  an implementation of a {@link BundleSource}
-     * @param acceptAnySpiffeId a Supplier of a Set of accepted SPIFFE IDs.
      */
-    public SpiffeTrustManager(@NonNull final BundleSource<X509Bundle> x509BundleSource,
-                              final boolean acceptAnySpiffeId) {
+    public SpiffeTrustManager(@NonNull final BundleSource<X509Bundle> x509BundleSource) {
         this.x509BundleSource = x509BundleSource;
         this.acceptedSpiffeIdsSupplier = Collections::emptySet;
-        this.acceptAnySpiffeId = acceptAnySpiffeId;
+        this.acceptAnySpiffeId = true;
     }
 
     /**

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeTrustManagerFactory.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeTrustManagerFactory.java
@@ -70,7 +70,7 @@ public class SpiffeTrustManagerFactory extends TrustManagerFactorySpi {
 
         final SpiffeTrustManager spiffeTrustManager;
         if (ACCEPT_ANY_SPIFFE_ID) {
-            spiffeTrustManager = new SpiffeTrustManager(x509Source, true);
+            spiffeTrustManager = new SpiffeTrustManager(x509Source);
         } else {
             spiffeTrustManager = new SpiffeTrustManager(x509Source, DEFAULT_SPIFFE_ID_SET_SUPPLIER);
         }
@@ -92,8 +92,7 @@ public class SpiffeTrustManagerFactory extends TrustManagerFactorySpi {
         final SpiffeTrustManager spiffeTrustManager;
 
         if (ACCEPT_ANY_SPIFFE_ID) {
-            // make explicit that all SPIFFE IDs will be accepted
-            spiffeTrustManager = new SpiffeTrustManager(x509BundleSource, true);
+            spiffeTrustManager = new SpiffeTrustManager(x509BundleSource);
         } else {
             spiffeTrustManager = new SpiffeTrustManager(x509BundleSource, DEFAULT_SPIFFE_ID_SET_SUPPLIER);
         }
@@ -108,7 +107,7 @@ public class SpiffeTrustManagerFactory extends TrustManagerFactorySpi {
      * @return an instance of a {@link TrustManager} wrapped in an array. The actual type returned is {@link SpiffeTrustManager}
      */
     public TrustManager[] engineGetTrustManagersAcceptAnySpiffeId(@NonNull final BundleSource<X509Bundle> x509BundleSource) {
-        val spiffeTrustManager = new SpiffeTrustManager(x509BundleSource, true);
+        val spiffeTrustManager = new SpiffeTrustManager(x509BundleSource);
         return new TrustManager[]{spiffeTrustManager};
     }
 

--- a/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeSslContextFactoryTest.java
+++ b/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeSslContextFactoryTest.java
@@ -23,8 +23,12 @@ class SpiffeSslContextFactoryTest {
 
     @Test
     void getSslContext_withX509Source() {
-        SpiffeSslContextFactory.SslContextOptions options = SpiffeSslContextFactory.SslContextOptions
-                .builder().x509Source(x509Source).build();
+        SpiffeSslContextFactory.SslContextOptions options =
+                SpiffeSslContextFactory.SslContextOptions
+                        .builder()
+                        .x509Source(x509Source)
+                        .acceptAnySpiffeId()
+                        .build();
         try {
             assertNotNull(SpiffeSslContextFactory.getSslContext(options));
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
@@ -34,8 +38,12 @@ class SpiffeSslContextFactoryTest {
 
     @Test
     void getSslContext_withSupplierOfSpiffeIds() {
-        SpiffeSslContextFactory.SslContextOptions options = SpiffeSslContextFactory.SslContextOptions
-                .builder().x509Source(x509Source).acceptedSpiffeIdsSupplier(Collections::emptySet).build();
+        SpiffeSslContextFactory.SslContextOptions options =
+                SpiffeSslContextFactory.SslContextOptions
+                        .builder()
+                        .x509Source(x509Source)
+                        .acceptedSpiffeIdsSupplier(Collections::emptySet)
+                        .build();
         try {
             assertNotNull(SpiffeSslContextFactory.getSslContext(options));
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
@@ -45,8 +53,12 @@ class SpiffeSslContextFactoryTest {
 
     @Test
     void getSslContext_withAcceptAny() {
-        SpiffeSslContextFactory.SslContextOptions options = SpiffeSslContextFactory.SslContextOptions
-                .builder().x509Source(x509Source).acceptAnySpiffeId(true).build();
+        SpiffeSslContextFactory.SslContextOptions options =
+                SpiffeSslContextFactory.SslContextOptions
+                        .builder()
+                        .x509Source(x509Source)
+                        .acceptAnySpiffeId()
+                        .build();
         try {
             assertNotNull(SpiffeSslContextFactory.getSslContext(options));
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
@@ -56,8 +68,13 @@ class SpiffeSslContextFactoryTest {
 
     @Test
     void getSslContext_withOtherSslProtocol() {
-        SpiffeSslContextFactory.SslContextOptions options = SpiffeSslContextFactory.SslContextOptions
-                .builder().x509Source(x509Source).sslProtocol("TLSv1.1").build();
+        SpiffeSslContextFactory.SslContextOptions options =
+                SpiffeSslContextFactory.SslContextOptions
+                        .builder()
+                        .x509Source(x509Source)
+                        .acceptAnySpiffeId()
+                        .sslProtocol("TLSv1.1")
+                        .build();
         try {
             assertNotNull(SpiffeSslContextFactory.getSslContext(options));
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
@@ -76,11 +93,33 @@ class SpiffeSslContextFactoryTest {
 
     @Test
     void getSslContext_nullX509Source() throws KeyManagementException, NoSuchAlgorithmException {
-        SpiffeSslContextFactory.SslContextOptions options = SpiffeSslContextFactory.SslContextOptions.builder().build();
+        SpiffeSslContextFactory.SslContextOptions options =
+                SpiffeSslContextFactory.SslContextOptions
+                        .builder()
+                        .acceptAnySpiffeId()
+                        .build();
         try {
             SpiffeSslContextFactory.getSslContext(options);
         } catch (IllegalArgumentException e) {
             assertEquals("x509Source option cannot be null, an X.509 Source must be provided", e.getMessage());
+        }
+    }
+
+    @Test
+    void getSslContext_noSupplierAndAcceptAnyNotSet() {
+        SpiffeSslContextFactory.SslContextOptions options =
+                SpiffeSslContextFactory.SslContextOptions
+                        .builder()
+                        .x509Source(x509Source)
+                        .build();
+        try {
+            SpiffeSslContextFactory.getSslContext(options);
+            fail();
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            fail(e);
+        } catch (IllegalArgumentException e) {
+            assertEquals("SSL context should be configured either with a Supplier " +
+                    "of accepted SPIFFE IDs or with acceptAnySpiffeId=true", e.getMessage());
         }
     }
 }

--- a/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeSslSocketFactoryTest.java
+++ b/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeSslSocketFactoryTest.java
@@ -28,7 +28,12 @@ class SpiffeSslSocketFactoryTest {
     @BeforeEach
     void setup() throws NoSuchAlgorithmException, KeyManagementException {
         X509SourceStub x509Source = new X509SourceStub();
-        SpiffeSslContextFactory.SslContextOptions options = SpiffeSslContextFactory.SslContextOptions.builder().x509Source(x509Source).build();
+        SpiffeSslContextFactory.SslContextOptions options =
+                SpiffeSslContextFactory.SslContextOptions
+                        .builder()
+                        .x509Source(x509Source)
+                        .acceptAnySpiffeId()
+                        .build();
         spiffeSslSocketFactory = new SpiffeSslSocketFactory(options);
         SSLContext sslContext = SpiffeSslContextFactory.getSslContext(options);
         socketFactory = sslContext.getSocketFactory();

--- a/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeTrustManagerTest.java
+++ b/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeTrustManagerTest.java
@@ -75,7 +75,7 @@ public class SpiffeTrustManagerTest {
     @Test
     void testCreateSpiffeTrustManager_nullSource() {
         try {
-            new SpiffeTrustManager(null, true);
+            new SpiffeTrustManager(null);
             fail();
         } catch (Exception e) {
             assertEquals("x509BundleSource is marked non-null but is null", e.getMessage());
@@ -277,7 +277,7 @@ public class SpiffeTrustManagerTest {
         acceptedSpiffeIds = Collections.singleton(SpiffeId.parse("spiffe://example.org/other"));
         when(bundleSource.getBundleForTrustDomain(TrustDomain.of("example.org"))).thenReturn(bundleKnown);
 
-        spiffeTrustManager = new SpiffeTrustManager(bundleSource, true);
+        spiffeTrustManager = new SpiffeTrustManager(bundleSource);
 
         try {
             spiffeTrustManager.checkClientTrusted(chain, "");
@@ -291,7 +291,7 @@ public class SpiffeTrustManagerTest {
         acceptedSpiffeIds = Collections.singleton(SpiffeId.parse("spiffe://example.org/other"));
         when(bundleSource.getBundleForTrustDomain(TrustDomain.of("example.org"))).thenReturn(bundleKnown);
 
-        spiffeTrustManager = new SpiffeTrustManager(bundleSource, true);
+        spiffeTrustManager = new SpiffeTrustManager(bundleSource);
 
         try {
             spiffeTrustManager.checkClientTrusted(chain, "");


### PR DESCRIPTION
Improve how the SpiffeTrustManager is configured to either validate SPIFFE IDs or acceptAny.
Validate the SslContextOptions.
Add visibility to some validation errors by logging warnings.
Improve log of the X509Source update.
Improve Spiffe Provider README.

Bump version to 0.6.2