### PR TITLE
Upgrading dependencies versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ X.509 and JWT SVIDs and bundles.
 Download
 --------
 
-The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.6.2). 
+The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.6.3). 
 
 The dependencies can be added to `pom.xml`
 
@@ -35,7 +35,7 @@ To import the `java-spiffe-provider` component:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-provider</artifactId>
-  <version>0.6.2</version>
+  <version>0.6.3</version>
 </dependency>
 ```
 The `java-spiffe-provider` component imports the `java-spiffe-core` component.
@@ -45,7 +45,7 @@ To just import the `java-spiffe-core` component:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-core</artifactId>
-  <version>0.6.2</version>
+  <version>0.6.3</version>
 </dependency>
 ```
 
@@ -53,12 +53,12 @@ Using Gradle:
 
 Import `java-spiffe-provider`:
 ```gradle
-implementation group: 'io.spiffe', name: 'java-spiffe-provider', version: '0.6.2'
+implementation group: 'io.spiffe', name: 'java-spiffe-provider', version: '0.6.3'
 ```
 
 Import `java-spiffe-core`:
 ```gradle
-implementation group: 'io.spiffe', name: 'java-spiffe-core', version: '0.6.2'
+implementation group: 'io.spiffe', name: 'java-spiffe-core', version: '0.6.3'
 ```
 
 ### MacOS Support
@@ -68,22 +68,22 @@ Add to your `pom.xml`:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>grpc-netty-macos</artifactId>
-  <version>0.6.2</version>
+  <version>0.6.3</version>
   <scope>runtime</scope>
 </dependency>
 ```
 
 Using Gradle:
 ```gradle
-runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos', version: '0.6.2'
+runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos', version: '0.6.3'
 ```
 
 ### Note: `java-spiffe-helper` artifact
 
 As the [java-spiffe-helper](java-spiffe-helper/README.md) artifact is meant to be used as a standalone JAR and not as a Maven dependency, 
-it is not published to Maven Central, but to [Github releases](https://github.com/spiffe/java-spiffe/releases/tag/v0.6.2), for both 
-[Linux](https://github.com/spiffe/java-spiffe/releases/download/v0.6.2/java-spiffe-helper-0.6.2-linux-x86_64.jar) and 
-[MacOS](https://github.com/spiffe/java-spiffe/releases/download/v0.6.2/java-spiffe-helper-0.6.2-osx-x86_64.jar) versions.
+it is not published to Maven Central, but to [Github releases](https://github.com/spiffe/java-spiffe/releases/tag/v0.6.3), for both 
+[Linux](https://github.com/spiffe/java-spiffe/releases/download/v0.6.3/java-spiffe-helper-0.6.3-linux-x86_64.jar) and 
+[MacOS](https://github.com/spiffe/java-spiffe/releases/download/v0.6.3/java-spiffe-helper-0.6.3-osx-x86_64.jar) versions.
 
 ### Build the JARs
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,14 +12,14 @@ allprojects {
 
 subprojects {
     group = 'io.spiffe'
-    version = '0.6.2'
+    version = '0.6.3'
 
     ext {
-        grpcVersion = '1.31.1'
-        jupiterVersion = '5.6.2'
-        mockitoVersion = '3.5.2'
-        lombokVersion = '1.18.12'
-        nimbusVersion = '8.20'
+        grpcVersion = '1.33.0'
+        jupiterVersion = '5.7.0'
+        mockitoVersion = '3.5.15'
+        lombokVersion = '1.18.16'
+        nimbusVersion = '9.1'
     }
 
     apply plugin: 'java-library'

--- a/java-spiffe-core/build.gradle
+++ b/java-spiffe-core/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath group: 'com.google.protobuf', name: 'protobuf-gradle-plugin', version: '0.8.12'
+        classpath group: 'com.google.protobuf', name: 'protobuf-gradle-plugin', version: '0.8.13'
     }
 }
 
@@ -24,7 +24,7 @@ sourceSets {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.12.0'
+        artifact = 'com.google.protobuf:protoc:3.13.0'
     }
     plugins {
         grpc {

--- a/java-spiffe-core/src/main/java/io/spiffe/spiffeid/SpiffeId.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/spiffeid/SpiffeId.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 /**
- * Represents a SPIFFE ID as defined in SPIFFE standard.
+ * Represents a SPIFFE ID as defined in the SPIFFE standard.
  * <p>
  * @see <a href="https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md">https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md</a>
  */

--- a/java-spiffe-core/src/main/java/io/spiffe/spiffeid/TrustDomain.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/spiffeid/TrustDomain.java
@@ -10,7 +10,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 /**
- * Represents a normalized SPIFFE trust domain (e.g. 'domain.test').
+ * Represents the name of a SPIFFE trust domain (e.g. 'domain.test').
  */
 @Value
 public class TrustDomain {

--- a/java-spiffe-helper/README.md
+++ b/java-spiffe-helper/README.md
@@ -10,15 +10,15 @@ The Helper automatically gets the SVID updates and stores them in the KeyStore a
 
 On Linux:
 
-`java -jar java-spiffe-helper-0.6.2-linux-x86_64.jar -c helper.conf`
+`java -jar java-spiffe-helper-0.6.3-linux-x86_64.jar -c helper.conf`
 
 On Mac OS:
 
-`java -jar java-spiffe-helper-0.6.2-osx-x86_64.jar -c helper.conf`
-
-(The jar can be found in `build/libs`, after running the gradle build)
+`java -jar java-spiffe-helper-0.6.3-osx-x86_64.jar -c helper.conf`
 
 Either `-c` or `--config` should be used to pass the path to the config file.
+
+(The jar can be downloaded from [Github releases](https://github.com/spiffe/java-spiffe/releases/tag/v0.6.3))
 
 ## Config file
 

--- a/java-spiffe-provider/README.md
+++ b/java-spiffe-provider/README.md
@@ -1,14 +1,12 @@
 # Java SPIFFE Provider
 
 This module provides a Java Security Provider implementation supporting X.509-SVIDs and methods for
-creating SSLContexts that are backed by the Workload API.
+creating `SSLContext` that are backed by the Workload API.
 
 ## Create an SSL Context backed by the Workload API
 
-To create an SSL Context that uses a `X509Source` backed by the Workload API, having the environment variable
-` SPIFFE_ENDPOINT_SOCKET` defined with the Workload API endpoint address.
-The `SSLContext` is configured with a set of SPIFFE IDs that the current workload
-will trust for TLS connections:
+To create an `javax.net.ssl.SSLContext` that is backed by the Workload API through a `X509Source`, having the environment variable
+` SPIFFE_ENDPOINT_SOCKET` defined with the Workload API endpoint address:
 
 ```
     X509Source source = DefaultX509Source.newSource();
@@ -20,9 +18,12 @@ will trust for TLS connections:
             .build();
 
     SSLContext sslContext = SpiffeSslContextFactory.getSslContext(options);
- ```
+```
+
+The `SSLContext` is configured with a set of SPIFFE IDs that will be trusted for TLS connections.
+
     
-Alternatively, a different Workload API address can be used by passing it to the X509Source creation method.
+Alternatively, a different Workload API address can be used by passing it to the `X509Source` creation method.
 
 ```
     X509SourceOptions sourceOptions = X509SourceOptions
@@ -154,7 +155,7 @@ A Tomcat TLS connector that uses the `Spiffe` KeyStore can be configured as foll
 
 ### Create mTLS GRPC server and client
 
-Prerequisite: Having the SPIFFE Provided configured through the `java.security`.
+Prerequisite: Having the SPIFFE Provider configured through the `java.security`.
 
 A `GRPC Server` using an SSL context backed by the Workload API:
 


### PR DESCRIPTION
Upgrading Grpc and Nimbus dependencies to the latest versions: grpc=1.33 and nimbus=9.1
Upgrading the other dependencies.

Minor amendments in readmes and comments.
Bump to 0.6.3

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>