### PR TITLE
Use google osdetector plugin instead of internal gradle class.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/java-spiffe-core/build.gradle
+++ b/java-spiffe-core/build.gradle
@@ -39,7 +39,7 @@ protobuf {
 }
 
 dependencies {
-    if (gradle.ext.isMacOsX) {
+    if (osdetector.os.is('osx') ) {
         compileOnly(project('grpc-netty-macos'))
         testImplementation(project('grpc-netty-macos'))
     } else {

--- a/java-spiffe-helper/build.gradle
+++ b/java-spiffe-helper/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     api(project(':java-spiffe-core'))
 
     // runtimeOnly grpc-netty dependency module will be included in the shadowJar
-    if (gradle.ext.isMacOsX) {
+    if (osdetector.os.is('osx') ) {
         runtimeOnly(project(':java-spiffe-core:grpc-netty-macos'))
     } else {
         runtimeOnly(project(':java-spiffe-core:grpc-netty-linux'))

--- a/java-spiffe-provider/build.gradle
+++ b/java-spiffe-provider/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     api(project(":java-spiffe-core"))
 
     // runtimeOnly grpc-netty dependency module will be included in the shadowJar
-    if (gradle.ext.isMacOsX) {
+    if (osdetector.os.is('osx') ) {
         runtimeOnly(project(':java-spiffe-core:grpc-netty-macos'))
     } else {
         runtimeOnly(project(':java-spiffe-core:grpc-netty-linux'))

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,3 @@
-import org.gradle.internal.os.OperatingSystem
-gradle.ext.isMacOsX = OperatingSystem.current().isMacOsX()
-
 rootProject.name = 'java-spiffe'
 include 'java-spiffe-core'
 include 'java-spiffe-provider'


### PR DESCRIPTION
Replace the internal class OperatingSystem by the osdetector plugin. 
Upgrade gradle wrapper to 6.7.1

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>