### PR TITLE
Make SPIFFE ID and TrustDomain compliant with the specs

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/spiffeid/SpiffeId.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/spiffeid/SpiffeId.java
@@ -19,6 +19,8 @@ public class SpiffeId {
 
     public static final String SPIFFE_SCHEME = "spiffe";
     public static final int SPIFFE_ID_MAXIMUM_LENGTH = 2048;
+    static final String MAXIMUM_LENGTH_ERROR_MESSAGE =
+            String.format("SPIFFE ID: maximum length is %d bytes", SPIFFE_ID_MAXIMUM_LENGTH);
 
     TrustDomain trustDomain;
 
@@ -92,7 +94,6 @@ public class SpiffeId {
     }
 
     private static URI createAndValidateUri(final String uriAsString) {
-
         URI uri;
         try {
             uri = URI.create(uriAsString.trim());
@@ -101,7 +102,8 @@ public class SpiffeId {
         }
 
         if (uri.toASCIIString().length() > SPIFFE_ID_MAXIMUM_LENGTH) {
-            throw new IllegalArgumentException(String.format("SPIFFE ID: maximum length is %s bytes", SPIFFE_ID_MAXIMUM_LENGTH));
+            throw new IllegalArgumentException(MAXIMUM_LENGTH_ERROR_MESSAGE);
+
         }
 
         val scheme = uri.getScheme();

--- a/java-spiffe-core/src/main/java/io/spiffe/spiffeid/TrustDomain.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/spiffeid/TrustDomain.java
@@ -16,6 +16,8 @@ import java.net.URISyntaxException;
 public class TrustDomain {
 
     public static final int TRUST_DOMAIN_MAXIMUM_LENGTH = 255;
+    static final String MAXIMUM_LENGTH_ERROR_MESSAGE
+            = String.format("Trust domain maximum length is %d bytes", TRUST_DOMAIN_MAXIMUM_LENGTH);
 
     String name;
 
@@ -75,7 +77,7 @@ public class TrustDomain {
      * @return a String formatted as a SPIFFE ID
      */
     public String toIdString() {
-        return String.format("%s://%s", SpiffeId.SPIFFE_SCHEME, name);
+        return SpiffeId.SPIFFE_SCHEME + "://" + name;
     }
 
     private static void validateHost(final String host) {
@@ -84,7 +86,7 @@ public class TrustDomain {
         }
 
         if (host.length() > TRUST_DOMAIN_MAXIMUM_LENGTH) {
-            throw new IllegalArgumentException(String.format("Trust domain maximum length is %s bytes", TRUST_DOMAIN_MAXIMUM_LENGTH));
+            throw new IllegalArgumentException(MAXIMUM_LENGTH_ERROR_MESSAGE);
         }
     }
 

--- a/java-spiffe-core/src/main/java/io/spiffe/spiffeid/TrustDomain.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/spiffeid/TrustDomain.java
@@ -15,6 +15,8 @@ import java.net.URISyntaxException;
 @Value
 public class TrustDomain {
 
+    public static final int TRUST_DOMAIN_MAXIMUM_LENGTH = 255;
+
     String name;
 
     private TrustDomain(final String trustDomain) {
@@ -67,9 +69,22 @@ public class TrustDomain {
         return name;
     }
 
+    /**
+     * Returns the trust domain as SPIFFE ID string (e.g. 'spiffe://example.org')
+     *
+     * @return a String formatted as a SPIFFE ID
+     */
+    public String toIdString() {
+        return String.format("%s://%s", SpiffeId.SPIFFE_SCHEME, name);
+    }
+
     private static void validateHost(final String host) {
         if (StringUtils.isBlank(host)) {
             throw new IllegalArgumentException("Trust domain cannot be empty");
+        }
+
+        if (host.length() > TRUST_DOMAIN_MAXIMUM_LENGTH) {
+            throw new IllegalArgumentException(String.format("Trust domain maximum length is %s bytes", TRUST_DOMAIN_MAXIMUM_LENGTH));
         }
     }
 

--- a/java-spiffe-core/src/test/java/io/spiffe/spiffeid/SpiffeIdTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/spiffeid/SpiffeIdTest.java
@@ -1,6 +1,7 @@
 package io.spiffe.spiffeid;
 
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -8,69 +9,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class SpiffeIdTest {
-
-    @Test
-    void of_TrustDomainAndPathSegments_ReturnsSpiffeIdWithTrustDomainAndPathWithSegments() {
-        val trustDomain = TrustDomain.of("trust-domain.org");
-
-        val spiffeId = SpiffeId.of(trustDomain, "path1", "path2");
-
-        assertAll("spiffeId",
-                () -> assertEquals("trust-domain.org", spiffeId.getTrustDomain().toString()),
-                () -> assertEquals("/path1/path2", spiffeId.getPath())
-        );
-    }
-
-    @Test
-    void of_TrustDomainAndNoPaths_ReturnsSpiffeIdWithTrustDomain() {
-        val trustDomain = TrustDomain.of("trust-domain.org");
-
-        val spiffeId = SpiffeId.of(trustDomain);
-
-        assertAll("spiffeId",
-                () -> assertEquals("trust-domain.org", spiffeId.getTrustDomain().toString()),
-                () -> assertEquals("", spiffeId.getPath())
-        );
-    }
-
-    @Test
-    void of_TrustDomainAndPathsWithCaps_ReturnsSpiffeIdNormalized() {
-        val trustDomain = TrustDomain.of("TRuST-DoMAIN.Org");
-
-        val spiffeId = SpiffeId.of(trustDomain, "PATH1", "paTH2");
-
-        assertAll("normalized spiffeId",
-                () -> assertEquals("trust-domain.org", spiffeId.getTrustDomain().toString()),
-                () -> assertEquals("/path1/path2", spiffeId.getPath())
-        );
-    }
-
-    @Test
-    void of_TrustDomainAndPathWithLeadingAndTrailingBlanks_ReturnsSpiffeIdNormalized() {
-        val trustDomain = TrustDomain.of(" trust-domain.org ");
-
-        val spiffeId = SpiffeId.of(trustDomain, " path1 ", " path2 ");
-
-        assertAll("normalized spiffeId",
-                () -> assertEquals("trust-domain.org", spiffeId.getTrustDomain().toString()),
-                () -> assertEquals("/path1/path2", spiffeId.getPath())
-        );
-    }
-
-    @Test
-    void of_NullTrustDomain_throwsException() {
-        try {
-            SpiffeId.of(null);
-        } catch (NullPointerException e) {
-            assertEquals("trustDomain is marked non-null but is null", e.getMessage());
-        }
-    }
+class SpiffeIdTest {
 
     @Test
     void toString_SpiffeId_ReturnsTheSpiffeIdInAStringFormatIncludingTheSchema() {
@@ -82,89 +26,37 @@ public class SpiffeIdTest {
         assertEquals("spiffe://trust-domain.org/path1/path2/path3", spiffeIdToString);
     }
 
-    @Test
-    void memberOf_aTrustDomainAndASpiffeIdWithSameTrustDomain_ReturnTrue() {
-        val trustDomain = TrustDomain.of("trust-domain.org");
-        val spiffeId = SpiffeId.of(trustDomain, "path1", "path2");
-
-        val isMemberOf = spiffeId.memberOf(TrustDomain.of("trust-domain.org"));
-
-        assertTrue(isMemberOf);
+    @ParameterizedTest
+    @MethodSource("provideTestValidSpiffeIds")
+    void testParseValidSpiffeId(String input, TrustDomain expectedTrustDomain, String expectedPath) {
+        SpiffeId result;
+        try {
+            result = SpiffeId.parse(input);
+            assertEquals(expectedTrustDomain, result.getTrustDomain());
+            assertEquals(expectedPath, result.getPath());
+        } catch (Exception e) {
+            fail("Unexpected error", e);
+        }
     }
 
-    @Test
-    void memberOf_aTrustDomainAndASpiffeIdWithDifferentTrustDomain_ReturnFalse() {
-        val trustDomain = TrustDomain.of("trust-domain.org");
-        val spiffeId = SpiffeId.of(trustDomain, "path1", "path2");
-
-        val isMemberOf = spiffeId.memberOf(TrustDomain.of("other-domain.org"));
-
-        assertFalse(isMemberOf);
-    }
-
-    @Test
-    void parse_aString_ReturnsASpiffeIdThatHasTrustDomainAndPathSegments() {
-        val spiffeIdAsString = "spiffe://trust-domain.org/path1/path2";
-
-        val spiffeId = SpiffeId.parse(spiffeIdAsString);
-
-        assertAll("SpiffeId",
-                () -> assertEquals("trust-domain.org", spiffeId.getTrustDomain().toString()),
-                () -> assertEquals("/path1/path2", spiffeId.getPath())
-        );
-    }
-
-    @Test
-    void parse_aStringContainingLeadingAndTrailingBlanks_ReturnsASpiffeIdThatHasTrustDomainAndPathSegments() {
-        val spiffeIdAsString = " spiffe://trust-domain.org/path1/path2 ";
-
-        val spiffeId = SpiffeId.parse(spiffeIdAsString);
-
-        assertAll("SpiffeId",
-                () -> assertEquals("trust-domain.org", spiffeId.getTrustDomain().toString()),
-                () -> assertEquals("/path1/path2", spiffeId.getPath())
-        );
-    }
-
-    @Test
-    void parse_pathWithColons() {
-        val spiffeIdAsString = " spiffe://domain.test/pa:th/element: ";
-
-        val spiffeId = SpiffeId.parse(spiffeIdAsString);
-
-        assertAll("SpiffeId",
-                () -> assertEquals("domain.test", spiffeId.getTrustDomain().toString()),
-                () -> assertEquals("/pa:th/element:", spiffeId.getPath())
-        );
-    }
-
-    @Test
-    void parse_pathWithAt() {
-        val spiffeIdAsString = "spiffe://domain.test/pa@th/element:";
-
-        val spiffeId = SpiffeId.parse(spiffeIdAsString);
-
-        assertAll("SpiffeId",
-                () -> assertEquals("domain.test", spiffeId.getTrustDomain().toString()),
-                () -> assertEquals("/pa@th/element:", spiffeId.getPath())
-        );
-    }
-
-    @Test
-    void parse_pathHasEncodedSubdelims() {
-        val spiffeIdAsString = "spiffe://domain.test/p!a$t&h'/(e)l*e+m,e;n=t";
-
-        val spiffeId = SpiffeId.parse(spiffeIdAsString);
-
-        assertAll("SpiffeId",
-                () -> assertEquals("domain.test", spiffeId.getTrustDomain().toString()),
-                () -> assertEquals("/p!a$t&h'/(e)l*e+m,e;n=t", spiffeId.getPath())
+    static Stream<Arguments> provideTestValidSpiffeIds() {
+        return Stream.of(
+                Arguments.of("spiffe://example.org", TrustDomain.of("example.org"), ""),
+                Arguments.of("spiffe://example.org/path", TrustDomain.of("example.org"), "/path"),
+                Arguments.of("spiffe://example.org/path1/path2", TrustDomain.of("example.org"), "/path1/path2"),
+                Arguments.of("spiffe://example.org/PATH1/PATH2", TrustDomain.of("example.org"), "/PATH1/PATH2"),
+                Arguments.of("SPIFFE://EXAMPLE.ORG/path1/path2", TrustDomain.of("example.org"), "/path1/path2"),
+                Arguments.of("spiffe://example.org/p!a$t&h'/(e)l*e+m,e;n=t", TrustDomain.of("example.org"), "/p!a$t&h'/(e)l*e+m,e;n=t"),
+                Arguments.of("spiffe://example.org/p@th", TrustDomain.of("example.org"), "/p@th"),
+                Arguments.of("spiffe://example.org/pa:th/element:", TrustDomain.of("example.org"), "/pa:th/element:"),
+                Arguments.of("  spiffe://domain.test/path1/path2  ", TrustDomain.of("domain.test"), "/path1/path2"),
+                Arguments.of("spiffe://example.org/9eebccd2-12bf-40a6-b262-65fe0487d453", TrustDomain.of("example.org"), "/9eebccd2-12bf-40a6-b262-65fe0487d453")
         );
     }
 
     @ParameterizedTest
-    @MethodSource("provideTestInvalidSpiffeIds")
-    void testParseTrustDomain(String input, Object expected) {
+    @MethodSource("provideInvalidSpiffeIds")
+    void testParseInvalidSpiffeId(String input, String expected) {
         SpiffeId result;
         try {
             result = SpiffeId.parse(input);
@@ -174,11 +66,11 @@ public class SpiffeIdTest {
         }
     }
 
-    static Stream<Arguments> provideTestInvalidSpiffeIds() {
+    static Stream<Arguments> provideInvalidSpiffeIds() {
         return Stream.of(
                 Arguments.of("", "SPIFFE ID cannot be empty"),
                 Arguments.of(null, "SPIFFE ID cannot be empty"),
-                Arguments.of("192.168.2.2:6688", "Illegal character in scheme name at index 0: 192.168.2.2:6688"),
+                Arguments.of("192.168.2.2:6688", "SPIFFE ID: malformed URI: 192.168.2.2:6688"),
                 Arguments.of("http://domain.test/path/element", "SPIFFE ID: invalid scheme"),
                 Arguments.of("spiffe:///path/element", "SPIFFE ID: trust domain is empty"),
                 Arguments.of("spiffe://domain.test/path/element?query=1", "SPIFFE ID: query is not allowed"),
@@ -187,8 +79,109 @@ public class SpiffeIdTest {
                 Arguments.of("spiffe://user:password@test.org/path/element", "SPIFFE ID: user info is not allowed"),
                 Arguments.of("spiffe:path/element", "SPIFFE ID: trust domain is empty"),
                 Arguments.of("spiffe:/path/element", "SPIFFE ID: trust domain is empty"),
-                Arguments.of("spiffe://domain.test/path/elem%5uent", "Malformed escape pair at index 30: spiffe://domain.test/path/elem%5uent")
+                Arguments.of("spiffe://domain.test/path/elem%5uent", "SPIFFE ID: malformed URI: spiffe://domain.test/path/elem%5uent")
         );
     }
 
+    @ParameterizedTest
+    @MethodSource("provideValidTrustDomainAndPaths")
+    void testOf(TrustDomain inputTrustDomain, String[] inputPath, SpiffeId expectedSpiffeId) {
+        SpiffeId result;
+        try {
+            result = SpiffeId.of(inputTrustDomain, inputPath);
+            assertEquals(result, expectedSpiffeId);
+        } catch (Exception e) {
+            fail("Unexpected error", e);
+        }
+    }
+
+    static Stream<Arguments> provideValidTrustDomainAndPaths() {
+        return Stream.of(
+                Arguments.of(TrustDomain.of("example.org"), new String[]{""}, SpiffeId.parse("spiffe://example.org")),
+                Arguments.of(TrustDomain.of("example.org"), new String[]{"path"}, SpiffeId.parse("spiffe://example.org/path")),
+                Arguments.of(TrustDomain.of("example.org"), new String[]{"path1", "path2"}, SpiffeId.parse("spiffe://example.org/path1/path2")),
+                Arguments.of(TrustDomain.of("example.org"), new String[]{"PATH1", "PATH2"}, SpiffeId.parse("spiffe://example.org/PATH1/PATH2")),
+                Arguments.of(TrustDomain.of("EXAMPLE.ORG"), new String[]{"path1", "path2"}, SpiffeId.parse("spiffe://example.org/path1/path2")),
+                Arguments.of(TrustDomain.of("example.org"), new String[]{"p!a$t&h'", "(e)l*e+m,e;n=t"}, SpiffeId.parse("spiffe://example.org/p!a$t&h'/(e)l*e+m,e;n=t")),
+                Arguments.of(TrustDomain.of("example.org"), new String[]{"p@th"}, SpiffeId.parse("spiffe://example.org/p@th")),
+                Arguments.of(TrustDomain.of("example.org"), new String[]{"p:ath", "element:"}, SpiffeId.parse("spiffe://example.org/p:ath/element:")),
+                Arguments.of(TrustDomain.of("  example.org  "), new String[]{"  path1  ", "  path2  "}, SpiffeId.parse("spiffe://example.org/path1/path2")),
+                Arguments.of(TrustDomain.of("example.org"), new String[]{"9eebccd2-12bf-40a6-b262-65fe0487d453"}, SpiffeId.parse("spiffe://example.org/9eebccd2-12bf-40a6-b262-65fe0487d453"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidArguments")
+    void testOfInvalid(TrustDomain trustDomain, String[] inputPath, String expectedError) {
+        SpiffeId result;
+        try {
+            SpiffeId.of(trustDomain, inputPath);
+            fail(String.format("Expected error %s", expectedError));
+        } catch (Exception e) {
+            assertEquals(expectedError, e.getMessage());
+        }
+    }
+
+    static Stream<Arguments> provideInvalidArguments() {
+        return Stream.of(
+                Arguments.of(null, new String[]{""}, "trustDomain is marked non-null but is null"),
+                Arguments.of(TrustDomain.of("domain.test"), new String[]{"elem%5uent"}, "SPIFFE ID: malformed URI: spiffe://domain.test/elem%5uent")
+        );
+    }
+
+    @Test
+    void memberOf_aTrustDomainAndASpiffeIdWithSameTrustDomain_ReturnsTrue() {
+        val trustDomain = TrustDomain.of("trust-domain.org");
+        val spiffeId = SpiffeId.of(trustDomain, "path1", "path2");
+
+        val isMemberOf = spiffeId.memberOf(TrustDomain.of("trust-domain.org"));
+
+        assertTrue(isMemberOf);
+    }
+
+    @Test
+    void memberOf_aTrustDomainAndASpiffeIdWithDifferentTrustDomain_ReturnsFalse() {
+        val trustDomain = TrustDomain.of("trust-domain.org");
+        val spiffeId = SpiffeId.of(trustDomain, "path1", "path2");
+
+        val isMemberOf = spiffeId.memberOf(TrustDomain.of("other-domain.org"));
+
+        assertFalse(isMemberOf);
+    }
+
+    @Test
+    void test_exceedsMaximumSpiffeIdLength() {
+        val path = StringUtils.repeat("a", 2028);
+        val spiffeIdString = String.format("spiffe://example.org/%s", path);
+
+        try {
+            SpiffeId.parse(spiffeIdString);
+            fail("Expected maximum length validation error");
+        } catch (IllegalArgumentException e) {
+            assertEquals("SPIFFE ID: maximum length is 2048 bytes", e.getMessage());
+        }
+
+        try {
+            val trustDomain = TrustDomain.of("example.org");
+            SpiffeId.of(trustDomain, path);
+            fail("Expected maximum length validation error");
+        } catch (IllegalArgumentException e) {
+            assertEquals("SPIFFE ID: maximum length is 2048 bytes", e.getMessage());
+        }
+    }
+
+    @Test
+    void test_MaximumSpiffeIdLength() {
+        val path = StringUtils.repeat("a", 2027);
+        val spiffeIdString = String.format("spiffe://example.org/%s", path);
+
+        try {
+            SpiffeId.parse(spiffeIdString);
+
+            val trustDomain = TrustDomain.of("example.org");
+            SpiffeId.of(trustDomain, path);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/spiffeid/SpiffeIdTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/spiffeid/SpiffeIdTest.java
@@ -57,10 +57,9 @@ class SpiffeIdTest {
     @ParameterizedTest
     @MethodSource("provideInvalidSpiffeIds")
     void testParseInvalidSpiffeId(String input, String expected) {
-        SpiffeId result;
         try {
-            result = SpiffeId.parse(input);
-            assertEquals(expected, result.toString());
+            SpiffeId.parse(input);
+            fail("Expected validation SPIFFE ID error");
         } catch (Exception e) {
             assertEquals(expected, e.getMessage());
         }
@@ -86,9 +85,8 @@ class SpiffeIdTest {
     @ParameterizedTest
     @MethodSource("provideValidTrustDomainAndPaths")
     void testOf(TrustDomain inputTrustDomain, String[] inputPath, SpiffeId expectedSpiffeId) {
-        SpiffeId result;
         try {
-            result = SpiffeId.of(inputTrustDomain, inputPath);
+            SpiffeId result = SpiffeId.of(inputTrustDomain, inputPath);
             assertEquals(result, expectedSpiffeId);
         } catch (Exception e) {
             fail("Unexpected error", e);
@@ -113,7 +111,6 @@ class SpiffeIdTest {
     @ParameterizedTest
     @MethodSource("provideInvalidArguments")
     void testOfInvalid(TrustDomain trustDomain, String[] inputPath, String expectedError) {
-        SpiffeId result;
         try {
             SpiffeId.of(trustDomain, inputPath);
             fail(String.format("Expected error %s", expectedError));
@@ -150,7 +147,7 @@ class SpiffeIdTest {
     }
 
     @Test
-    void test_exceedsMaximumSpiffeIdLength() {
+    void test_parse_exceedsMaximumSpiffeIdLength() {
         val path = StringUtils.repeat("a", 2028);
         val spiffeIdString = String.format("spiffe://example.org/%s", path);
 
@@ -160,9 +157,15 @@ class SpiffeIdTest {
         } catch (IllegalArgumentException e) {
             assertEquals("SPIFFE ID: maximum length is 2048 bytes", e.getMessage());
         }
+    }
+
+    @Test
+    void test_of_exceedsMaximumSpiffeIdLength() {
+        val path = StringUtils.repeat("a", 2028);
+        val spiffeIdString = String.format("spiffe://example.org/%s", path);
+        val trustDomain = TrustDomain.of("example.org");
 
         try {
-            val trustDomain = TrustDomain.of("example.org");
             SpiffeId.of(trustDomain, path);
             fail("Expected maximum length validation error");
         } catch (IllegalArgumentException e) {
@@ -174,11 +177,10 @@ class SpiffeIdTest {
     void test_MaximumSpiffeIdLength() {
         val path = StringUtils.repeat("a", 2027);
         val spiffeIdString = String.format("spiffe://example.org/%s", path);
+        val trustDomain = TrustDomain.of("example.org");
 
         try {
             SpiffeId.parse(spiffeIdString);
-
-            val trustDomain = TrustDomain.of("example.org");
             SpiffeId.of(trustDomain, path);
         } catch (Exception e) {
             fail(e);

--- a/java-spiffe-core/src/test/java/io/spiffe/spiffeid/TrustDomainTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/spiffeid/TrustDomainTest.java
@@ -43,6 +43,12 @@ public class TrustDomainTest {
     }
 
     @Test
+    void test_toIdString() {
+        val trustDomain = TrustDomain.of("domain.test");
+        assertEquals("spiffe://domain.test", trustDomain.toIdString());
+    }
+
+    @Test
     void testGetName() {
         TrustDomain trustDomain = TrustDomain.of("test.domain");
         assertEquals("test.domain", trustDomain.getName());

--- a/java-spiffe-core/src/test/java/io/spiffe/spiffeid/TrustDomainTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/spiffeid/TrustDomainTest.java
@@ -1,5 +1,8 @@
 package io.spiffe.spiffeid;
 
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -8,6 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TrustDomainTest {
 
@@ -60,5 +64,28 @@ public class TrustDomainTest {
                 Arguments.of("/path/element", "Trust domain cannot be empty"),
                 Arguments.of("spiffe://domain.test:80", "Trust Domain: port is not allowed")
         );
+    }
+
+    @Test
+    void test_exceedsMaximumTrustDomainLength() {
+        val name = StringUtils.repeat("a", 256);
+
+        try {
+            TrustDomain.of(name);
+            Assertions.fail("Expected maximum trust domain validation error");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Trust domain maximum length is 255 bytes", e.getMessage());
+        }
+    }
+
+    @Test
+    void test_maximumTrustDomainLength() {
+        val name = StringUtils.repeat("a", 255);
+
+        try {
+            TrustDomain.of(name);
+        } catch (Exception e) {
+            fail(e);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes and adds validations according to the standard: https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md

* Add validation SPIFFE ID maximum length of 2048 
* Add validation TrustDomain maximum length of 255
* Fix parse SPIFFE ID to preserve path case.

The tests for SPIFFE ID and TrustDomain were refactored. 

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>