### PR TITLE
Remove private/public key match verification.

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/svid/x509svid/X509Svid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/x509svid/X509Svid.java
@@ -145,7 +145,6 @@ public class X509Svid {
         val privateKey = generatePrivateKey(privateKeyBytes, keyFileFormat, x509Certificates);
         val spiffeId = getSpiffeId(x509Certificates);
 
-        validatePrivateKey(privateKey, x509Certificates);
         validateLeafCertificate(x509Certificates.get(0));
 
         // there are intermediate CA certificates
@@ -223,15 +222,6 @@ public class X509Svid {
         }
         if (CertificateUtils.hasKeyUsageCRLSign(leaf)) {
             throw new X509SvidException("Leaf certificate must not have 'cRLSign' as key usage");
-        }
-    }
-
-    private static void validatePrivateKey(final PrivateKey privateKey, final List<X509Certificate> x509Certificates)
-            throws X509SvidException {
-        try {
-            CertificateUtils.validatePrivateKey(privateKey, x509Certificates.get(0));
-        } catch (InvalidKeyException e) {
-            throw new X509SvidException("Private Key does not match Certificate Public Key", e);
         }
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidTest.java
@@ -24,10 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class X509SvidTest {
+class X509SvidTest {
 
     static String keyRSA = "testdata/x509svid/key-pkcs8-rsa.pem";
-    static String keyRSAOther = "testdata/x509svid/key-rsa-other.pem";
     static String certSingle = "testdata/x509svid/good-leaf-only.pem";
     static String leafNoDigitalSignature = "testdata/x509svid/wrong-leaf-no-digital-signature.pem";
     static String leafCRLSign = "testdata/x509svid/wrong-leaf-crl-sign.pem";
@@ -39,7 +38,6 @@ public class X509SvidTest {
     static String keyECDSA = "testdata/x509svid/key-pkcs8-ecdsa.pem";
     static String certMultiple = "testdata/x509svid/good-leaf-and-intermediate.pem";
     static String corrupted = "testdata/x509svid/corrupted";
-    static String keyECDSAOther = "testdata/x509svid/key-ecdsa-other.pem";
     static String keyDER = "testdata/x509svid/keyEC.der";
     static String certDER = "testdata/x509svid/cert.der";
 
@@ -99,23 +97,7 @@ public class X509SvidTest {
                 ),
                 Arguments.of(TestCase
                         .builder()
-                        .name("7. Certificate does not match private key: RSA keys")
-                        .certsPath(certSingle)
-                        .keyPath(keyRSAOther)
-                        .expectedError("Private Key does not match Certificate Public Key")
-                        .build()
-                ),
-                Arguments.of(TestCase
-                        .builder()
-                        .name("8. Certificate does not match private key: EC keys")
-                        .certsPath(certMultiple)
-                        .keyPath(keyECDSAOther)
-                        .expectedError("Private Key does not match Certificate Public Key")
-                        .build()
-                ),
-                Arguments.of(TestCase
-                        .builder()
-                        .name("9. Certificate without SPIFFE ID")
+                        .name("7. Certificate without SPIFFE ID")
                         .certsPath(leafEmptyID)
                         .keyPath(keyRSA)
                         .expectedError("Certificate does not contain SPIFFE ID in the URI SAN")
@@ -123,7 +105,7 @@ public class X509SvidTest {
                 ),
                 Arguments.of(TestCase
                         .builder()
-                        .name("10. Leaf certificate with CA flag set to true")
+                        .name("8. Leaf certificate with CA flag set to true")
                         .certsPath(leafCAtrue)
                         .keyPath(keyRSA)
                         .expectedError("Leaf certificate must not have CA flag set to true")
@@ -131,7 +113,7 @@ public class X509SvidTest {
                 ),
                 Arguments.of(TestCase
                         .builder()
-                        .name("11. Leaf certificate without digitalSignature as key usage")
+                        .name("9. Leaf certificate without digitalSignature as key usage")
                         .certsPath(leafNoDigitalSignature)
                         .keyPath(keyRSA)
                         .expectedError("Leaf certificate must have 'digitalSignature' as key usage")
@@ -139,7 +121,7 @@ public class X509SvidTest {
                 ),
                 Arguments.of(TestCase
                         .builder()
-                        .name("12. Leaf certificate with certSign as key usage")
+                        .name("10. Leaf certificate with certSign as key usage")
                         .certsPath(leafCertSign)
                         .keyPath(keyRSA)
                         .expectedError("Leaf certificate must not have 'keyCertSign' as key usage")
@@ -147,7 +129,7 @@ public class X509SvidTest {
                 ),
                 Arguments.of(TestCase
                         .builder()
-                        .name("13. Leaf certificate with cRLSign as key usage")
+                        .name("11. Leaf certificate with cRLSign as key usage")
                         .certsPath(leafCRLSign)
                         .keyPath(keyRSA)
                         .expectedError("Leaf certificate must not have 'cRLSign' as key usage")
@@ -155,7 +137,7 @@ public class X509SvidTest {
                 ),
                 Arguments.of(TestCase
                         .builder()
-                        .name("14. Signing certificate without CA flag")
+                        .name("12. Signing certificate without CA flag")
                         .certsPath(signNoCA)
                         .keyPath(keyRSA)
                         .expectedError("Signing certificate must have CA flag set to true")
@@ -163,7 +145,7 @@ public class X509SvidTest {
                 ),
                 Arguments.of(TestCase
                         .builder()
-                        .name("15. Signing certificate without CA flag")
+                        .name("13. Signing certificate without CA flag")
                         .certsPath(signNoKeyCertSign)
                         .keyPath(keyRSA)
                         .expectedError("Signing certificate must have 'keyCertSign' as key usage")


### PR DESCRIPTION
Since there is no real requirement about verifying the private keys and public keys that come from the Workload API, and there is no straightforward way to do it in Java because because private key objects in Java don't have any of the public key properties we decided to remove the verification that is currently in place using the Random generator and that is causing these long delays and serving stale certificates.

Fixes #55 

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>