### PR TITLE
Validate JWT 'typ' header.

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
@@ -9,12 +9,12 @@ import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import io.spiffe.internal.JwtSignatureAlgorithm;
 import io.spiffe.bundle.BundleSource;
 import io.spiffe.bundle.jwtbundle.JwtBundle;
 import io.spiffe.exception.AuthorityNotFoundException;
 import io.spiffe.exception.BundleNotFoundException;
 import io.spiffe.exception.JwtSvidException;
+import io.spiffe.internal.JwtSignatureAlgorithm;
 import io.spiffe.spiffeid.SpiffeId;
 import lombok.NonNull;
 import lombok.Value;
@@ -25,7 +25,6 @@ import java.security.PublicKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -64,7 +63,8 @@ public class JwtSvid {
      */
     String token;
 
-    private static final List<String> VALID_TYPE_HEADER_VALUES = Arrays.asList("JWT", "JOSE");
+    public static final String HEADER_TYP_JWT = "JWT";
+    public static final String HEADER_TYP_JOSE = "JOSE";
 
     private JwtSvid(final SpiffeId spiffeId,
                     final Set<String> audience,
@@ -98,8 +98,7 @@ public class JwtSvid {
      *                                    provided as parameter
      * @throws IllegalArgumentException   when the token is blank or cannot be parsed
      * @throws BundleNotFoundException    if the bundle for the trust domain of the spiffe id from the 'sub'
-     *                                    cannot be found
-     *                                    in the JwtBundleSource
+     *                                    cannot be found in the JwtBundleSource
      * @throws AuthorityNotFoundException if the authority cannot be found in the bundle using the value from
      *                                    the 'kid' header
      */
@@ -146,7 +145,7 @@ public class JwtSvid {
      * from 'exp' claim.
      * @throws JwtSvidException         when the token expired or the expiration claim is missing,
      *                                  when the 'aud' has an audience that is not in the audience provided as parameter,
-     *                                  when the 'alg' is not supported (See {@link JwtSignatureAlgorithm})
+     *                                  when the 'alg' is not supported (See {@link JwtSignatureAlgorithm}),
      *                                  when the header 'typ' is present and is not 'JWT' or 'JOSE'.
      * @throws IllegalArgumentException when the token cannot be parsed
      */
@@ -316,7 +315,8 @@ public class JwtSvid {
         if (type == null || StringUtils.isBlank(type.toString())) {
             return;
         }
-        if (!VALID_TYPE_HEADER_VALUES.contains(type.toString())) {
+        final String typValue = type.toString();
+        if (!HEADER_TYP_JWT.equals(typValue) && !HEADER_TYP_JOSE.equals(typValue)) {
             throw new JwtSvidException(String.format("If JWT header 'typ' is present, it must be either 'JWT' or 'JOSE'. Got: '%s'.", type.toString()));
         }
     }

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
@@ -124,38 +124,38 @@ class JwtSvidParseAndValidateTest {
         jwtBundle.putJwtAuthority("authority3", key3.getPublic());
 
         SpiffeId spiffeId = trustDomain.newSpiffeId("host");
-        Date expiration = new Date(System.currentTimeMillis() + 3600000);
+        Date expiration = new Date(System.currentTimeMillis() +  (60 * 60 * 1000));
         Set<String> audience = new HashSet<String>() {{add("audience1"); add("audience2");}};
 
         JWTClaimsSet claims = TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), expiration);
 
         return Stream.of(
                 Arguments.of(TestCase.builder()
-                        .name("1. using EC signature")
+                        .name("using EC signature")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(Collections.singleton("audience1"))
-                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", "JOSE"))
+                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", JwtSvid.HEADER_TYP_JOSE))
                         .expectedException(null)
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
                                 expiration,
-                                claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", "JOSE") ))
+                                claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", JwtSvid.HEADER_TYP_JOSE) ))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("2. using RSA signature")
+                        .name("using RSA signature")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
-                        .generateToken(() -> TestUtils.generateToken(claims, key3, "authority3", "JWT"))
+                        .generateToken(() -> TestUtils.generateToken(claims, key3, "authority3", JwtSvid.HEADER_TYP_JWT))
                         .expectedException(null)
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
                                 expiration,
-                                claims.getClaims(), TestUtils.generateToken(claims, key3, "authority3", "JWT")))
+                                claims.getClaims(), TestUtils.generateToken(claims, key3, "authority3", JwtSvid.HEADER_TYP_JWT)))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("3. using empty typ")
+                        .name("using empty typ")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(claims, key3, "authority3", ""))
@@ -181,105 +181,105 @@ class JwtSvidParseAndValidateTest {
         jwtBundle.putJwtAuthority("authority3", key3.getPublic());
 
         SpiffeId spiffeId = trustDomain.newSpiffeId("host");
-        Date expiration = new Date(System.currentTimeMillis() + 3600000);
+        Date expiration = new Date(System.currentTimeMillis() +  (60 * 60 * 1000));
         Set<String> audience = new HashSet<String>() {{add("audience1"); add("audience2");}};
 
         JWTClaimsSet claims = TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), expiration);
 
         return Stream.of(
                 Arguments.of(TestCase.builder()
-                        .name("1. malformed")
+                        .name("malformed")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> "invalid token")
                         .expectedException(new IllegalArgumentException("Unable to parse JWT token"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("2. unsupported algorithm")
+                        .name("unsupported algorithm")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(Collections.singleton("audience"))
                         .generateToken(() -> HS256TOKEN)
                         .expectedException(new JwtSvidException("Unsupported JWT algorithm: HS256"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("3. missing subject")
+                        .name("missing subject")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, "", expiration), key1, "authority1"))
                         .expectedException(new JwtSvidException("Token missing subject claim"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("4. missing expiration")
+                        .name("missing expiration")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), null), key1, "authority1"))
                         .expectedException(new JwtSvidException("Token missing expiration claim"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("5. token has expired")
+                        .name("token has expired")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), new Date()), key1, "authority1"))
                         .expectedException(new JwtSvidException("Token has expired"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("6. unexpected audience")
+                        .name("unexpected audience")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(Collections.singleton("another"))
                         .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1"))
                         .expectedException(new JwtSvidException("expected audience in [another] (audience=[audience2, audience1])"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("7. invalid subject claim")
+                        .name("invalid subject claim")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, "non-spiffe-subject", expiration), key1, "authority1"))
                         .expectedException(new JwtSvidException("Subject non-spiffe-subject cannot be parsed as a SPIFFE ID"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("8. missing key id")
+                        .name("missing key id")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(claims, key1, null))
                         .expectedException(new JwtSvidException("Token header missing key id"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("9. key id contains an empty value")
+                        .name("key id contains an empty value")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(claims, key1, "   "))
                         .expectedException(new JwtSvidException("Token header key id contains an empty value"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("10. no bundle for trust domain")
+                        .name("no bundle for trust domain")
                         .jwtBundle(new JwtBundle(TrustDomain.of("other.domain")))
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1"))
                         .expectedException(new BundleNotFoundException("No JWT bundle found for trust domain test.domain"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("11. no authority found for key id")
+                        .name("no authority found for key id")
                         .jwtBundle(new JwtBundle(TrustDomain.of("test.domain")))
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1"))
                         .expectedException(new AuthorityNotFoundException("No authority found for the trust domain test.domain and key id authority1"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("12. signature cannot be verified with authority")
+                        .name("signature cannot be verified with authority")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(claims, key2, "authority1"))
                         .expectedException(new JwtSvidException("Signature invalid: cannot be verified with the authority with keyId=authority1"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("13. authority algorithm mismatch")
+                        .name("authority algorithm mismatch")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(claims, key3, "authority1"))
                         .expectedException(new JwtSvidException("Error verifying signature with the authority with keyId=authority1"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("14. not valid header 'typ'")
+                        .name("not valid header 'typ'")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", "OTHER"))

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class JwtSvidParseInsecureTest {
 
@@ -33,9 +34,8 @@ class JwtSvidParseInsecureTest {
             "dCI6MTUxNjIzOTAyMiwiYXVkIjoiYXVkaWVuY2UifQ.wNm5pQGSLCw5N9ddgSF2hkgmQpGnG9le_gpiFmyBhao";
 
     @ParameterizedTest
-    @MethodSource("provideJwtScenarios")
-    void parseJwt(TestCase testCase) {
-
+    @MethodSource("provideSuccessScenarios")
+    void parseValidJwt(TestCase testCase) {
         try {
             String token = testCase.generateToken.get();
             JwtSvid jwtSvid = JwtSvid.parseInsecure(token, testCase.audience);
@@ -44,6 +44,18 @@ class JwtSvidParseInsecureTest {
             assertEquals(testCase.expectedJwtSvid.getAudience(), jwtSvid.getAudience());
             assertEquals(testCase.expectedJwtSvid.getExpiry().toInstant().getEpochSecond(), jwtSvid.getExpiry().toInstant().getEpochSecond());
             assertEquals(token, jwtSvid.getToken());
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideFailureScenarios")
+    void parseInvalidJwt(TestCase testCase) {
+        try {
+            String token = testCase.generateToken.get();
+            JwtSvid.parseInsecure(token, testCase.audience);
+            fail("expected error: " + testCase.expectedException.getMessage());
         } catch (Exception e) {
             assertEquals(testCase.expectedException.getClass(), e.getClass());
             assertEquals(testCase.expectedException.getMessage(), e.getMessage());
@@ -89,7 +101,7 @@ class JwtSvidParseInsecureTest {
         }
     }
 
-    static Stream<Arguments> provideJwtScenarios() {
+    static Stream<Arguments> provideSuccessScenarios() {
         KeyPair key1 = TestUtils.generateECKeyPair(Curve.P_521);
         KeyPair key2 = TestUtils.generateECKeyPair(Curve.P_521);
 
@@ -106,57 +118,97 @@ class JwtSvidParseInsecureTest {
 
         return Stream.of(
                 Arguments.of(TestCase.builder()
-                        .name("success")
+                        .name("1. using typ as JWT")
                         .expectedAudience(audience)
-                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1"))
+                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", "JWT"))
                         .expectedException(null)
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
                                 expiration,
-                                claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1")))
+                                claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", "JWT")))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("malformed")
+                        .name("2. using typ as JOSE")
+                        .expectedAudience(audience)
+                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", "JOSE"))
+                        .expectedException(null)
+                        .expectedJwtSvid(newJwtSvidInstance(
+                                trustDomain.newSpiffeId("host"),
+                                audience,
+                                expiration,
+                                claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", "JWT")))
+                        .build()),
+                Arguments.of(TestCase.builder()
+                        .name("3. using empty typ")
+                        .expectedAudience(audience)
+                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", ""))
+                        .expectedException(null)
+                        .expectedJwtSvid(newJwtSvidInstance(
+                                trustDomain.newSpiffeId("host"),
+                                audience,
+                                expiration,
+                                claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", "")))
+                        .build()));
+    }
+
+    static Stream<Arguments> provideFailureScenarios() {
+        KeyPair key1 = TestUtils.generateECKeyPair(Curve.P_521);
+        KeyPair key2 = TestUtils.generateECKeyPair(Curve.P_521);
+
+        TrustDomain trustDomain = TrustDomain.of("test.domain");
+        JwtBundle jwtBundle = new JwtBundle(trustDomain);
+        jwtBundle.putJwtAuthority("authority1", key1.getPublic());
+        jwtBundle.putJwtAuthority("authority2", key2.getPublic());
+
+        SpiffeId spiffeId = trustDomain.newSpiffeId("host");
+        Date expiration = new Date(System.currentTimeMillis() + 3600000);
+        Set<String> audience = Collections.singleton("audience");
+
+        JWTClaimsSet claims = TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), expiration);
+
+        return Stream.of(
+                Arguments.of(TestCase.builder()
+                        .name("1. malformed")
                         .expectedAudience(audience)
                         .generateToken(() -> "invalid token")
                         .expectedException(new IllegalArgumentException("Unable to parse JWT token"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("missing subject")
+                        .name("2. missing subject")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, "", expiration), key1, "authority1"))
                         .expectedException(new JwtSvidException("Token missing subject claim"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("missing expiration")
+                        .name("3. missing expiration")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), null), key1, "authority1"))
                         .expectedException(new JwtSvidException("Token missing expiration claim"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("token has expired")
+                        .name("4. token has expired")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), new Date()), key1, "authority1"))
                         .expectedException(new JwtSvidException("Token has expired"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("unexpected audience")
+                        .name("5. unexpected audience")
                         .expectedAudience(Collections.singleton("another"))
                         .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1"))
                         .expectedException(new JwtSvidException("expected audience in [another] (audience=[audience])"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("invalid subject claim")
+                        .name("6. invalid subject claim")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, "non-spiffe-subject", expiration), key1, "authority1"))
                         .expectedException(new JwtSvidException("Subject non-spiffe-subject cannot be parsed as a SPIFFE ID"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("unsupported algorithm")
-                        .expectedAudience(Collections.singleton("audience"))
-                        .generateToken(() -> HS256TOKEN)
-                        .expectedException(new JwtSvidException("Unsupported JWT algorithm: HS256"))
+                        .name("7. not valid header 'typ'")
+                        .expectedAudience(audience)
+                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", "OTHER"))
+                        .expectedException(new JwtSvidException("If JWT header 'typ' is present, it must be either 'JWT' or 'JOSE'. Got: 'OTHER'."))
                         .build())
         );
     }

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
@@ -118,29 +118,29 @@ class JwtSvidParseInsecureTest {
 
         return Stream.of(
                 Arguments.of(TestCase.builder()
-                        .name("1. using typ as JWT")
+                        .name("using typ as JWT")
                         .expectedAudience(audience)
-                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", "JWT"))
+                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", JwtSvid.HEADER_TYP_JWT))
                         .expectedException(null)
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
                                 expiration,
-                                claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", "JWT")))
+                                claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", JwtSvid.HEADER_TYP_JWT)))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("2. using typ as JOSE")
+                        .name("using typ as JOSE")
                         .expectedAudience(audience)
-                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", "JOSE"))
+                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", JwtSvid.HEADER_TYP_JOSE))
                         .expectedException(null)
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
                                 expiration,
-                                claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", "JWT")))
+                                claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", JwtSvid.HEADER_TYP_JWT)))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("3. using empty typ")
+                        .name("using empty typ")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", ""))
                         .expectedException(null)
@@ -169,43 +169,43 @@ class JwtSvidParseInsecureTest {
 
         return Stream.of(
                 Arguments.of(TestCase.builder()
-                        .name("1. malformed")
+                        .name("malformed")
                         .expectedAudience(audience)
                         .generateToken(() -> "invalid token")
                         .expectedException(new IllegalArgumentException("Unable to parse JWT token"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("2. missing subject")
+                        .name("missing subject")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, "", expiration), key1, "authority1"))
                         .expectedException(new JwtSvidException("Token missing subject claim"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("3. missing expiration")
+                        .name("missing expiration")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), null), key1, "authority1"))
                         .expectedException(new JwtSvidException("Token missing expiration claim"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("4. token has expired")
+                        .name("token has expired")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), new Date()), key1, "authority1"))
                         .expectedException(new JwtSvidException("Token has expired"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("5. unexpected audience")
+                        .name("unexpected audience")
                         .expectedAudience(Collections.singleton("another"))
                         .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1"))
                         .expectedException(new JwtSvidException("expected audience in [another] (audience=[audience])"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("6. invalid subject claim")
+                        .name("invalid subject claim")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, "non-spiffe-subject", expiration), key1, "authority1"))
                         .expectedException(new JwtSvidException("Subject non-spiffe-subject cannot be parsed as a SPIFFE ID"))
                         .build()),
                 Arguments.of(TestCase.builder()
-                        .name("7. not valid header 'typ'")
+                        .name("not valid header 'typ'")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1", "OTHER"))
                         .expectedException(new JwtSvidException("If JWT header 'typ' is present, it must be either 'JWT' or 'JOSE'. Got: 'OTHER'."))

--- a/java-spiffe-core/src/testFixtures/java/io/spiffe/utils/TestUtils.java
+++ b/java-spiffe-core/src/testFixtures/java/io/spiffe/utils/TestUtils.java
@@ -1,6 +1,7 @@
 package io.spiffe.utils;
 
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
@@ -57,10 +58,14 @@ public class TestUtils {
 
     public static String generateToken(Map<String, Object> claims, KeyPair keyPair, String keyId) {
         JWTClaimsSet jwtClaimsSet = buildJWTClaimSetFromClaimsMap(claims);
-        return generateToken(jwtClaimsSet, keyPair, keyId);
+        return generateToken(jwtClaimsSet, keyPair, keyId, "JWT");
     }
 
     public static String generateToken(JWTClaimsSet claims, KeyPair keyPair, String keyId) {
+        return generateToken(claims, keyPair, keyId, "JWT");
+    }
+
+    public static String generateToken(JWTClaimsSet claims, KeyPair keyPair, String keyId, String typ) {
         try {
             JWSAlgorithm algorithm;
             JWSSigner signer;
@@ -74,7 +79,9 @@ public class TestUtils {
                 throw new IllegalArgumentException("Algorithm not supported");
             }
 
-            SignedJWT signedJWT = new SignedJWT(new JWSHeader.Builder(algorithm).keyID(keyId).build(), claims);
+            final JOSEObjectType joseTyp = new JOSEObjectType(typ);
+            final JWSHeader header = new JWSHeader.Builder(algorithm).keyID(keyId).type(joseTyp).build();
+            SignedJWT signedJWT = new SignedJWT(header, claims);
             signedJWT.sign(signer);
             return signedJWT.serialize();
         } catch (JOSEException e) {

--- a/java-spiffe-core/src/testFixtures/java/io/spiffe/utils/TestUtils.java
+++ b/java-spiffe-core/src/testFixtures/java/io/spiffe/utils/TestUtils.java
@@ -10,6 +10,7 @@ import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import io.spiffe.svid.jwtsvid.JwtSvid;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -58,11 +59,11 @@ public class TestUtils {
 
     public static String generateToken(Map<String, Object> claims, KeyPair keyPair, String keyId) {
         JWTClaimsSet jwtClaimsSet = buildJWTClaimSetFromClaimsMap(claims);
-        return generateToken(jwtClaimsSet, keyPair, keyId, "JWT");
+        return generateToken(jwtClaimsSet, keyPair, keyId, JwtSvid.HEADER_TYP_JWT);
     }
 
     public static String generateToken(JWTClaimsSet claims, KeyPair keyPair, String keyId) {
-        return generateToken(claims, keyPair, keyId, "JWT");
+        return generateToken(claims, keyPair, keyId, JwtSvid.HEADER_TYP_JWT);
     }
 
     public static String generateToken(JWTClaimsSet claims, KeyPair keyPair, String keyId, String typ) {


### PR DESCRIPTION
Validates that in case the `typ` header is present, it is either `JWT` or `JOSE`.

Addresses #58 

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>