### PR TITLE
Implement FetchX509Bundles method on WorkloadAPI client

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/GrpcConversionUtils.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/GrpcConversionUtils.java
@@ -59,11 +59,12 @@ final class GrpcConversionUtils {
     }
 
     static X509BundleSet toX509BundleSet(final Workload.X509BundlesResponse bundlesResponse) throws X509BundleException {
-        if (bundlesResponse.getBundlesMap().size() == 0) {
+        val bundlesCount = bundlesResponse.getBundlesCount();
+        if (bundlesCount == 0) {
             throw new X509BundleException("X.509 Bundle response from the Workload API is empty");
         }
 
-        final List<X509Bundle> x509Bundles = new ArrayList<>();
+        final List<X509Bundle> x509Bundles = new ArrayList<>(bundlesCount);
         for (Map.Entry<String, ByteString> entry : bundlesResponse.getBundlesMap().entrySet()) {
             X509Bundle x509Bundle = createX509Bundle(entry);
             x509Bundles.add(x509Bundle);

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/WorkloadApiClient.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/WorkloadApiClient.java
@@ -1,8 +1,10 @@
 package io.spiffe.workloadapi;
 
 import io.spiffe.bundle.jwtbundle.JwtBundleSet;
+import io.spiffe.bundle.x509bundle.X509BundleSet;
 import io.spiffe.exception.JwtBundleException;
 import io.spiffe.exception.JwtSvidException;
+import io.spiffe.exception.X509BundleException;
 import io.spiffe.exception.X509ContextException;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.svid.jwtsvid.JwtSvid;
@@ -35,6 +37,25 @@ public interface WorkloadApiClient extends Closeable {
      * @param watcher an instance that implements a {@link Watcher}.
      */
     void watchX509Context(@NonNull Watcher<X509Context> watcher);
+
+    /**
+     * Fetches the X.509 bundles on a one-shot blocking call.
+     *
+     * @return an instance of a {@link X509BundleSet} containing the X.509 bundles keyed by TrustDomain
+     * @throws X509BundleException if there is an error fetching or processing the X.509 bundles
+     */
+    X509BundleSet fetchX509Bundles() throws X509BundleException;
+
+    /**
+     * Watches for X.509 bundles updates.
+     * <p>
+     * A new Stream to the Workload API is opened for each call to this method, so that the client starts getting
+     * updates immediately after the Stream is ready and doesn't have to wait until the Workload API dispatches
+     * the next update.
+     *
+     * @param watcher an instance that implements a {@link Watcher} for {@link X509BundleSet}.
+     */
+    void watchX509Bundles(@NonNull Watcher<X509BundleSet> watcher);
 
     /**
      * Fetches a SPIFFE JWT-SVID on one-shot blocking call.

--- a/java-spiffe-core/src/main/proto/workload.proto
+++ b/java-spiffe-core/src/main/proto/workload.proto
@@ -42,6 +42,13 @@ message X509SVID {
     bytes bundle = 4;
 }
 
+message X509BundlesRequest {}
+
+message X509BundlesResponse {
+    // x509 certificates, keyed by trust domain URI
+    map<string, bytes> bundles = 1;
+}
+
 message JWTSVID {
     string spiffe_id = 1;
 
@@ -91,5 +98,6 @@ service SpiffeWorkloadAPI {
     // well as related information like trust bundles and CRLs. As
     // this information changes, subsequent messages will be sent.
     rpc FetchX509SVID(X509SVIDRequest) returns (stream X509SVIDResponse);
+    rpc FetchX509Bundles(X509BundlesRequest) returns (stream X509BundlesResponse);
 }
 

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientEmptyResponseTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientEmptyResponseTest.java
@@ -2,8 +2,10 @@ package io.spiffe.workloadapi;
 
 import io.grpc.testing.GrpcCleanupRule;
 import io.spiffe.bundle.jwtbundle.JwtBundleSet;
+import io.spiffe.bundle.x509bundle.X509BundleSet;
 import io.spiffe.exception.JwtBundleException;
 import io.spiffe.exception.JwtSvidException;
+import io.spiffe.exception.X509BundleException;
 import io.spiffe.exception.X509ContextException;
 import io.spiffe.spiffeid.SpiffeId;
 import org.junit.Rule;
@@ -35,7 +37,7 @@ class DefaultWorkloadApiClientEmptyResponseTest {
 
 
     @Test
-    public void testFetchX509Context_throwsX509ContextException() throws Exception {
+    void testFetchX509Context_throwsX509ContextException() throws Exception {
         try {
             workloadApiClient.fetchX509Context();
             fail();
@@ -45,9 +47,8 @@ class DefaultWorkloadApiClientEmptyResponseTest {
     }
 
     @Test
-    public void testWatchX509Context_onErrorIsCalledOnWatcher() throws Exception {
+    void testWatchX509Context_onErrorIsCalledOnWatcher() throws Exception {
         CountDownLatch done = new CountDownLatch(1);
-        final String[] error = new String[1];
         Watcher<X509Context> contextWatcher = new Watcher<X509Context>() {
             @Override
             public void onUpdate(X509Context update) {
@@ -56,13 +57,41 @@ class DefaultWorkloadApiClientEmptyResponseTest {
 
             @Override
             public void onError(Throwable e) {
-                error[0] = e.getMessage();
+                assertEquals("Error processing X.509 Context update", e.getMessage());
                 done.countDown();
             }
         };
         workloadApiClient.watchX509Context(contextWatcher);
         done.await();
-        assertEquals("Error processing X.509 Context update", error[0]);
+    }
+
+    @Test
+    void testFetchX509Bundles_throwsX509BundleException() {
+        try {
+            workloadApiClient.fetchX509Bundles();
+            fail();
+        } catch (X509BundleException e) {
+            assertEquals("Error fetching X.509 bundles", e.getMessage());
+        }
+    }
+
+    @Test
+    void testWatchX509Bundles_onErrorIsCalledOnWatched() throws InterruptedException {
+        CountDownLatch done = new CountDownLatch(1);
+        Watcher<X509BundleSet> contextWatcher = new Watcher<X509BundleSet>() {
+            @Override
+            public void onUpdate(X509BundleSet update) {
+                fail();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                assertEquals("Error processing X.509 bundles update", e.getMessage());
+                done.countDown();
+            }
+        };
+        workloadApiClient.watchX509Bundles(contextWatcher);
+        done.await();
     }
 
     @Test
@@ -110,7 +139,6 @@ class DefaultWorkloadApiClientEmptyResponseTest {
     @Test
     void testWatchJwtBundles_onErrorIsCalledOnWatched() throws InterruptedException {
         CountDownLatch done = new CountDownLatch(1);
-        final String[] error = new String[1];
         Watcher<JwtBundleSet> contextWatcher = new Watcher<JwtBundleSet>() {
             @Override
             public void onUpdate(JwtBundleSet update) {
@@ -119,12 +147,11 @@ class DefaultWorkloadApiClientEmptyResponseTest {
 
             @Override
             public void onError(Throwable e) {
-                error[0] = e.getMessage();
+                assertEquals("Error processing JWT bundles update", e.getMessage());
                 done.countDown();
             }
         };
         workloadApiClient.watchJwtBundles(contextWatcher);
         done.await();
-        assertEquals("Error processing JWT bundles update", error[0]);
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -155,7 +154,6 @@ class DefaultWorkloadApiClientTest {
 
     @Test
     void testFetchX509Bundles() {
-
         X509BundleSet x509BundleSet = null;
         try {
             x509BundleSet = workloadApiClient.fetchX509Bundles();
@@ -186,7 +184,6 @@ class DefaultWorkloadApiClientTest {
             public void onUpdate(X509BundleSet update) {
                 x509BundleSet[0] = update;
                 done.countDown();
-
             }
 
             @Override

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
@@ -141,7 +141,7 @@ class DefaultX509SourceTest {
     }
 
     @Test
-    void newSource_errorFetchingJwtBundles() {
+    void newSource_errorFetchingX509Context() {
         val options = DefaultX509Source.X509SourceOptions
                 .builder()
                 .workloadApiClient(workloadApiClientErrorStub)

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApi.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApi.java
@@ -81,6 +81,29 @@ class FakeWorkloadApi extends SpiffeWorkloadAPIImplBase {
         }
     }
 
+    @Override
+    public void fetchX509Bundles(Workload.X509BundlesRequest request, StreamObserver<Workload.X509BundlesResponse> responseObserver) {
+        try {
+            Path pathBundle = Paths.get(toUri(x509Bundle));
+            byte[] bundleBytes = Files.readAllBytes(pathBundle);
+            ByteString bundleByteString = ByteString.copyFrom(bundleBytes);
+
+            Path pathFederateBundle = Paths.get(toUri(federatedBundle));
+            byte[] federatedBundleBytes = Files.readAllBytes(pathFederateBundle);
+            ByteString federatedByteString = ByteString.copyFrom(federatedBundleBytes);
+
+            Workload.X509BundlesResponse response = Workload.X509BundlesResponse
+                    .newBuilder()
+                    .putBundles(TrustDomain.of("example.org").getName(), bundleByteString)
+                    .putBundles(TrustDomain.of("domain.test").getName(), federatedByteString)
+                    .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (URISyntaxException | IOException e) {
+            throw new Error("Failed FakeSpiffeWorkloadApiService.fetchX509Bundles", e);
+        }
+    }
 
     @Override
     public void fetchJWTSVID(Workload.JWTSVIDRequest request, StreamObserver<Workload.JWTSVIDResponse> responseObserver) {

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApiCorruptedResponses.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApiCorruptedResponses.java
@@ -48,6 +48,25 @@ class FakeWorkloadApiCorruptedResponses extends SpiffeWorkloadAPIImplBase {
         }
     }
 
+    @Override
+    public void fetchX509Bundles(Workload.X509BundlesRequest request, StreamObserver<Workload.X509BundlesResponse> responseObserver) {
+        Path pathBundle = null;
+        try {
+            pathBundle = Paths.get(toUri(corrupted));
+            byte[] bundleBytes = Files.readAllBytes(pathBundle);
+            ByteString corruptedByteString = ByteString.copyFrom(bundleBytes);
+
+            Workload.X509BundlesResponse response = Workload.X509BundlesResponse
+                    .newBuilder()
+                    .putBundles("example.org", corruptedByteString)
+                    .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (URISyntaxException | IOException e) {
+            throw new Error("Failed FakeSpiffeWorkloadApiService.fetchX509Bundles", e);
+        }
+    }
 
     @Override
     public void fetchJWTSVID(Workload.JWTSVIDRequest request, StreamObserver<Workload.JWTSVIDResponse> responseObserver) {

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApiEmptyResponse.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApiEmptyResponse.java
@@ -13,6 +13,12 @@ class FakeWorkloadApiEmptyResponse extends SpiffeWorkloadAPIImplBase {
     }
 
     @Override
+    public void fetchX509Bundles(Workload.X509BundlesRequest request, StreamObserver<Workload.X509BundlesResponse> responseObserver) {
+        responseObserver.onNext(Workload.X509BundlesResponse.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
     public void fetchJWTSVID(Workload.JWTSVIDRequest request, StreamObserver<Workload.JWTSVIDResponse> responseObserver) {
         responseObserver.onNext(Workload.JWTSVIDResponse.newBuilder().build());
         responseObserver.onCompleted();

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApiExceptions.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApiExceptions.java
@@ -21,6 +21,11 @@ class FakeWorkloadApiExceptions extends SpiffeWorkloadAPIImplBase {
     }
 
     @Override
+    public void fetchX509Bundles(Workload.X509BundlesRequest request, StreamObserver<Workload.X509BundlesResponse> responseObserver) {
+        responseObserver.onError(exception);
+    }
+
+    @Override
     public void fetchJWTSVID(Workload.JWTSVIDRequest request, StreamObserver<Workload.JWTSVIDResponse> responseObserver) {
         responseObserver.onError(exception);
     }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/GrpcConversionUtilsTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/GrpcConversionUtilsTest.java
@@ -105,7 +105,7 @@ class GrpcConversionUtilsTest {
 
     @Test
     void test_toX509BundleSet_fromEmptyIterator() {
-        final Iterator<Workload.X509BundlesResponse> iterator = Collections.EMPTY_LIST.iterator();
+        final Iterator<Workload.X509BundlesResponse> iterator = Collections.emptyListIterator();
         try {
             GrpcConversionUtils.toX509BundleSet(iterator);
             fail();

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/GrpcConversionUtilsTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/GrpcConversionUtilsTest.java
@@ -1,20 +1,38 @@
 package io.spiffe.workloadapi;
 
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import io.spiffe.bundle.x509bundle.X509Bundle;
+import io.spiffe.bundle.x509bundle.X509BundleSet;
+import io.spiffe.exception.BundleNotFoundException;
 import io.spiffe.exception.JwtBundleException;
+import io.spiffe.exception.X509BundleException;
 import io.spiffe.exception.X509ContextException;
 import io.spiffe.spiffeid.TrustDomain;
 import io.spiffe.workloadapi.grpc.Workload;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Set;
 
+import static io.spiffe.utils.TestUtils.toUri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class GrpcConversionUtilsTest {
 
+    final String x509Bundle = "testdata/workloadapi/bundle.der";
+    final String federatedBundle = "testdata/workloadapi/federated-bundle.pem";
+
     @Test
-    void toX509Context_emptyResponse() {
+    void test_toX509Context_emptyResponse() {
         Iterator<Workload.X509SVIDResponse> iterator = Collections.emptyIterator();
         try {
             GrpcConversionUtils.toX509Context(iterator);
@@ -24,21 +42,92 @@ class GrpcConversionUtilsTest {
     }
 
     @Test
-    void toBundleSet() {
+    void test_toJwtBundleSet_emtpyResponse() {
         Iterator<Workload.JWTBundlesResponse> iterator = Collections.emptyIterator();
         try {
-            GrpcConversionUtils.toBundleSet(iterator);
+            GrpcConversionUtils.toJwtBundleSet(iterator);
         } catch (JwtBundleException e) {
             assertEquals("JWT Bundle response from the Workload API is empty", e.getMessage());
         }
     }
 
     @Test
-    void parseX509Bundle_corruptedBytes() {
+    void test_parseX509Bundle_corruptedBytes() {
         try {
             GrpcConversionUtils.parseX509Bundle(TrustDomain.of("example.org"), "corrupted".getBytes());
         } catch (X509ContextException e) {
             assertEquals("X.509 Bundles could not be processed", e.getMessage());
         }
+    }
+
+    @Test
+    void test_toX509BundleSet_from_X509BundlesResponse() throws URISyntaxException, IOException {
+        Workload.X509BundlesResponse response = createX509BundlesResponse();
+
+        try {
+            X509BundleSet x509BundleSet = GrpcConversionUtils.toX509BundleSet(response);
+            X509Bundle bundle1 = x509BundleSet.getBundleForTrustDomain(TrustDomain.of("example.org"));
+            X509Bundle bundle2 = x509BundleSet.getBundleForTrustDomain(TrustDomain.of("domain.test"));
+            assertEquals(1, bundle1.getX509Authorities().size());
+            assertEquals(1, bundle2.getX509Authorities().size());
+        } catch (X509BundleException | BundleNotFoundException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void test_toX509BundleSet_from_X509BundlesResponseIterator() throws URISyntaxException, IOException {
+        Workload.X509BundlesResponse response = createX509BundlesResponse();
+        final Iterator<Workload.X509BundlesResponse> iterator = Collections.singleton(response).iterator();
+
+        try {
+            X509BundleSet x509BundleSet = GrpcConversionUtils.toX509BundleSet(iterator);
+            X509Bundle bundle1 = x509BundleSet.getBundleForTrustDomain(TrustDomain.of("example.org"));
+            X509Bundle bundle2 = x509BundleSet.getBundleForTrustDomain(TrustDomain.of("domain.test"));
+            assertEquals(1, bundle1.getX509Authorities().size());
+            assertEquals(1, bundle2.getX509Authorities().size());
+        } catch (X509BundleException | BundleNotFoundException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void test_toX509BundleSet_fromEmptyResponse() {
+        Workload.X509BundlesResponse response = Workload.X509BundlesResponse.newBuilder().build();
+        try {
+            GrpcConversionUtils.toX509BundleSet(response);
+            fail();
+        } catch (X509BundleException e) {
+            assertEquals("X.509 Bundle response from the Workload API is empty", e.getMessage());
+        }
+
+    }
+
+    @Test
+    void test_toX509BundleSet_fromEmptyIterator() {
+        final Iterator<Workload.X509BundlesResponse> iterator = Collections.EMPTY_LIST.iterator();
+        try {
+            GrpcConversionUtils.toX509BundleSet(iterator);
+            fail();
+        } catch (X509BundleException e) {
+            assertEquals("X.509 Bundle response from the Workload API is empty", e.getMessage());
+        }
+
+    }
+
+    private Workload.X509BundlesResponse createX509BundlesResponse() throws URISyntaxException, IOException {
+        Path pathBundle = Paths.get(toUri(x509Bundle));
+        byte[] bundleBytes = Files.readAllBytes(pathBundle);
+        ByteString bundleByteString = ByteString.copyFrom(bundleBytes);
+
+        Path pathFederateBundle = Paths.get(toUri(federatedBundle));
+        byte[] federatedBundleBytes = Files.readAllBytes(pathFederateBundle);
+        ByteString federatedByteString = ByteString.copyFrom(federatedBundleBytes);
+
+        return Workload.X509BundlesResponse
+                .newBuilder()
+                .putBundles(TrustDomain.of("example.org").getName(), bundleByteString)
+                .putBundles(TrustDomain.of("domain.test").getName(), federatedByteString)
+                .build();
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientErrorStub.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientErrorStub.java
@@ -1,8 +1,10 @@
 package io.spiffe.workloadapi;
 
 import io.spiffe.bundle.jwtbundle.JwtBundleSet;
+import io.spiffe.bundle.x509bundle.X509BundleSet;
 import io.spiffe.exception.JwtBundleException;
 import io.spiffe.exception.JwtSvidException;
+import io.spiffe.exception.X509BundleException;
 import io.spiffe.exception.X509ContextException;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.svid.jwtsvid.JwtSvid;
@@ -20,6 +22,16 @@ public class WorkloadApiClientErrorStub implements WorkloadApiClient {
     @Override
     public void watchX509Context(@NonNull final Watcher<X509Context> watcher) {
         watcher.onError(new X509ContextException("Testing exception"));
+    }
+
+    @Override
+    public X509BundleSet fetchX509Bundles() throws X509BundleException {
+        throw new X509BundleException("Testing exception");
+    }
+
+    @Override
+    public void watchX509Bundles(@NonNull Watcher<X509BundleSet> watcher) {
+        watcher.onError(new X509BundleException("Testing exception"));
     }
 
     @Override

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientStub.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientStub.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -52,6 +53,17 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
     public void watchX509Context(@NonNull final Watcher<X509Context> watcher) {
         val update = generateX509Context();
         watcher.onUpdate(update);
+    }
+
+    @Override
+    public X509BundleSet fetchX509Bundles() {
+        return generateX509BundleSet();
+    }
+
+    @Override
+    public void watchX509Bundles(@NonNull Watcher<X509BundleSet> watcher) {
+        val x509BundleSet = generateX509BundleSet();
+        watcher.onUpdate(x509BundleSet);
     }
 
     @Override
@@ -87,6 +99,18 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
             val jwtBundle = JwtBundle.parse(TrustDomain.of("example.org"), bundleBytes);
             return JwtBundleSet.of(Collections.singleton(jwtBundle));
         } catch (IOException | JwtBundleException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private X509BundleSet generateX509BundleSet() {
+        try {
+            val pathBundle = Paths.get(toUri(x509Bundle));
+            byte[] bundleBytes = Files.readAllBytes(pathBundle);
+            val x509Bundle1 = X509Bundle.parse(TrustDomain.of("example.org"), bundleBytes);
+            val x509Bundle2 = X509Bundle.parse(TrustDomain.of("domain.test"), bundleBytes);
+            return X509BundleSet.of(Arrays.asList(x509Bundle1, x509Bundle2));
+        } catch (IOException | X509BundleException | URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }

--- a/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientErrorStub.java
+++ b/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientErrorStub.java
@@ -1,8 +1,10 @@
 package io.spiffe.helper.keystore;
 
 import io.spiffe.bundle.jwtbundle.JwtBundleSet;
+import io.spiffe.bundle.x509bundle.X509BundleSet;
 import io.spiffe.exception.JwtBundleException;
 import io.spiffe.exception.JwtSvidException;
+import io.spiffe.exception.X509BundleException;
 import io.spiffe.exception.X509ContextException;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.svid.jwtsvid.JwtSvid;
@@ -23,6 +25,16 @@ public class WorkloadApiClientErrorStub implements WorkloadApiClient {
     @Override
     public void watchX509Context(@NonNull final Watcher<X509Context> watcher) {
         watcher.onError(new X509ContextException("Testing exception"));
+    }
+
+    @Override
+    public X509BundleSet fetchX509Bundles() throws X509BundleException {
+        throw new X509BundleException("Testing exception");
+    }
+
+    @Override
+    public void watchX509Bundles(@NonNull Watcher<X509BundleSet> watcher) {
+        watcher.onError(new X509BundleException("Testing exception"));
     }
 
     @Override

--- a/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientStub.java
+++ b/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientStub.java
@@ -23,6 +23,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 
 public class WorkloadApiClientStub implements WorkloadApiClient {
@@ -39,6 +40,17 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
     @Override
     public void watchX509Context(@NonNull final Watcher<X509Context> watcher) {
         val update = generateX509Context();
+        watcher.onUpdate(update);
+    }
+
+    @Override
+    public X509BundleSet fetchX509Bundles() throws X509BundleException {
+        return getX509BundleSet();
+    }
+
+    @Override
+    public void watchX509Bundles(@NonNull Watcher<X509BundleSet> watcher) {
+        val update = getX509BundleSet();
         watcher.onUpdate(update);
     }
 
@@ -83,6 +95,18 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
             Path pathBundle = Paths.get(toUri(x509Bundle));
             byte[] bundleBytes = Files.readAllBytes(pathBundle);
             return X509Bundle.parse(TrustDomain.of("example.org"), bundleBytes);
+        } catch (IOException | X509BundleException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private X509BundleSet getX509BundleSet() {
+        try {
+            Path pathBundle = Paths.get(toUri(x509Bundle));
+            byte[] bundleBytes = Files.readAllBytes(pathBundle);
+            val bundle1 = X509Bundle.parse(TrustDomain.of("example.org"), bundleBytes);
+            val bundle2 = X509Bundle.parse(TrustDomain.of("domain.test"), bundleBytes);
+            return X509BundleSet.of(Arrays.asList(bundle1, bundle2));
         } catch (IOException | X509BundleException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This PR adds support for the new Workload API method to fetch X.509 bundles. 

Two methods were added to the Workload API client: 

- fetchX509Bundles() : Fetches the X.509 bundles on a one-shot blocking call.
- watchX509Bundles(): Watches for X.509 bundles updates.

Tests were added to cover the new functionality.
    
Solves #61  