### PR TITLE
Update netty-transport-native-kqueue dependecy to 4.1.63

### DIFF
--- a/java-spiffe-core/grpc-netty-macos/build.gradle
+++ b/java-spiffe-core/grpc-netty-macos/build.gradle
@@ -2,7 +2,7 @@ description = "Java SPIFFE Library GRPC-Netty MacOS module"
 
 dependencies {
     implementation group: 'io.grpc', name: 'grpc-netty', version: "${grpcVersion}"
-    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.51.Final', classifier: 'osx-x86_64'
+    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.63.Final', classifier: 'osx-x86_64'
 }
 
 jar {


### PR DESCRIPTION
Update the Netty transport native dependency for MacOS.

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>