### PR TITLE
Add support to the SpiffeTrustManager for a SpiffeIdVerifier callback.

### DIFF
--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/AllowedIdSupplierSpiffeIdVerifier.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/AllowedIdSupplierSpiffeIdVerifier.java
@@ -16,8 +16,10 @@ public class AllowedIdSupplierSpiffeIdVerifier implements SpiffeIdVerifier {
     }
 
     @Override
-    public boolean verify(SpiffeId spiffeId, X509Certificate[] verifiedChain) {
+    public void verify(SpiffeId spiffeId, X509Certificate[] verifiedChain) throws SpiffeVerificationException {
         Set<SpiffeId> allowedSpiffeIds = allowedSpiffeIdsSupplier.get();
-        return allowedSpiffeIds.contains(spiffeId);
+        if (!allowedSpiffeIds.contains(spiffeId)) {
+            throw new SpiffeVerificationException(String.format("SPIFFE ID %s in X.509 certificate is not accepted", spiffeId));
+        }
     }
 }

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/AllowedIdSupplierSpiffeIdVerifier.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/AllowedIdSupplierSpiffeIdVerifier.java
@@ -1,0 +1,23 @@
+package io.spiffe.provider;
+
+import io.spiffe.spiffeid.SpiffeId;
+import lombok.NonNull;
+
+import java.security.cert.X509Certificate;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class AllowedIdSupplierSpiffeIdVerifier implements SpiffeIdVerifier {
+
+    private final Supplier<Set<SpiffeId>> allowedSpiffeIdsSupplier;
+
+    public AllowedIdSupplierSpiffeIdVerifier(@NonNull Supplier<Set<SpiffeId>> allowedSpiffeIdsSupplier) {
+        this.allowedSpiffeIdsSupplier = allowedSpiffeIdsSupplier;
+    }
+
+    @Override
+    public boolean verify(SpiffeId spiffeId, X509Certificate[] verifiedChain) {
+        Set<SpiffeId> allowedSpiffeIds = allowedSpiffeIdsSupplier.get();
+        return allowedSpiffeIds.contains(spiffeId);
+    }
+}

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeIdVerifier.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeIdVerifier.java
@@ -11,7 +11,7 @@ public interface SpiffeIdVerifier {
      *
      * @param spiffeId the SPIFFE ID of the SVID
      * @param verifiedChain the certificate chain with the X509-SVID certificate back to an X.509 root for the trust domain.
-     * @return true if the SPIFFE ID is acceptable
+     * @throws SpiffeVerificationException if there was an error verifying the SPIFFE ID or it wasn't considered valid.
      */
-    public boolean verify(SpiffeId spiffeId, X509Certificate[] verifiedChain);
+    public void verify(SpiffeId spiffeId, X509Certificate[] verifiedChain) throws SpiffeVerificationException;
 }

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeIdVerifier.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeIdVerifier.java
@@ -2,12 +2,16 @@ package io.spiffe.provider;
 
 import io.spiffe.spiffeid.SpiffeId;
 
+import java.security.cert.X509Certificate;
+
 public interface SpiffeIdVerifier {
     /**
-     * Verify that the SPIFFE ID is acceptable.
+     * Verify that an X509-SVID is acceptable. This method receives the SPIFFE ID of the SVID and the certificate
+     * chain.
      *
-     * @param spiffeId the peer SPIFFE ID
+     * @param spiffeId the SPIFFE ID of the SVID
+     * @param verifiedChain the certificate chain with the X509-SVID certificate back to an X.509 root for the trust domain.
      * @return true if the SPIFFE ID is acceptable
      */
-    public boolean verify(SpiffeId spiffeId);
+    public boolean verify(SpiffeId spiffeId, X509Certificate[] verifiedChain);
 }

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeIdVerifier.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeIdVerifier.java
@@ -1,0 +1,13 @@
+package io.spiffe.provider;
+
+import io.spiffe.spiffeid.SpiffeId;
+
+public interface SpiffeIdVerifier {
+    /**
+     * Verify that the SPIFFE ID is acceptable.
+     *
+     * @param spiffeId the peer SPIFFE ID
+     * @return true if the SPIFFE ID is acceptable
+     */
+    public boolean verify(SpiffeId spiffeId);
+}

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeTrustManager.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeTrustManager.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
  */
 public final class SpiffeTrustManager extends X509ExtendedTrustManager {
 
-    private static final SpiffeIdVerifier ALLOW_ANY_SPIFFE_ID_VERIFIER = (spiffeId, verifiedChain) -> true;
+    private static final SpiffeIdVerifier ALLOW_ANY_SPIFFE_ID_VERIFIER = (spiffeId, verifiedChain) -> {};
 
     private final BundleSource<X509Bundle> x509BundleSource;
     private final SpiffeIdVerifier spiffeIdVerifier;
@@ -158,8 +158,10 @@ public final class SpiffeTrustManager extends X509ExtendedTrustManager {
     // root CA in the bundle source
     private void validatePeerChain(final X509Certificate... chain) throws CertificateException {
         SpiffeId spiffeId = CertificateUtils.getSpiffeId(chain[0]);
-        if (!spiffeIdVerifier.verify(spiffeId, chain)) {
-            throw new CertificateException(String.format("SPIFFE ID %s in X.509 certificate is not accepted", spiffeId));
+        try {
+            spiffeIdVerifier.verify(spiffeId, chain);
+        } catch (SpiffeVerificationException e) {
+            throw new CertificateException(e.getMessage(), e);
         }
 
         try {

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeTrustManager.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeTrustManager.java
@@ -172,7 +172,7 @@ public final class SpiffeTrustManager extends X509ExtendedTrustManager {
             }
             if (spiffeIdVerifier != null) {
                 SpiffeId spiffeId = CertificateUtils.getSpiffeId(chain[0]);
-                if (!spiffeIdVerifier.verify(spiffeId)) {
+                if (!spiffeIdVerifier.verify(spiffeId, chain)) {
                     throw new CertificateException(String.format("SPIFFE ID %s in X.509 certificate is not accepted", spiffeId));
                 }
             }

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeVerificationException.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeVerificationException.java
@@ -1,0 +1,11 @@
+package io.spiffe.provider;
+
+/**
+ * This class indicates there was a problem verifying a peer's SPIFFE ID. The message should be used to indicate what
+ * issue was encountered.
+ */
+public class SpiffeVerificationException extends Exception {
+    public SpiffeVerificationException(String message) {
+        super(message);
+    }
+}

--- a/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeTrustManagerFactoryTest.java
+++ b/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeTrustManagerFactoryTest.java
@@ -13,9 +13,9 @@ import java.lang.reflect.Field;
 import java.util.UUID;
 
 import static io.spiffe.provider.SpiffeProviderConstants.SSL_SPIFFE_ACCEPT_PROPERTY;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SpiffeTrustManagerFactoryTest {
 
@@ -37,9 +37,9 @@ class SpiffeTrustManagerFactoryTest {
 
         TrustDomain trustDomain = TrustDomain.of("example.org");
         assertEquals(source.getBundleForTrustDomain(trustDomain), bundleSource.getBundleForTrustDomain(trustDomain));
-        assertTrue(spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test1"), null));
-        assertTrue(spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test2"), null));
-        assertFalse(spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test3"), null));
+        assertDoesNotThrow(() -> spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test1"), null));
+        assertDoesNotThrow(() -> spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test2"), null));
+        assertThrows(SpiffeVerificationException.class, () -> spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test3"), null));
     }
 
 
@@ -56,9 +56,9 @@ class SpiffeTrustManagerFactoryTest {
 
         TrustDomain trustDomain = TrustDomain.of("example.org");
         assertEquals(source.getBundleForTrustDomain(trustDomain), bundleSource.getBundleForTrustDomain(trustDomain));
-        assertTrue(spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test1"), null));
-        assertTrue(spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test2"), null));
-        assertFalse(spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test3"), null));
+        assertDoesNotThrow(() -> spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test1"), null));
+        assertDoesNotThrow(() -> spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test2"), null));
+        assertThrows(SpiffeVerificationException.class, () -> spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/test3"), null));
     }
 
     @Test
@@ -67,7 +67,7 @@ class SpiffeTrustManagerFactoryTest {
         TrustManager[] trustManagers = new SpiffeTrustManagerFactory().engineGetTrustManagersAcceptAnySpiffeId(source);
         SpiffeTrustManager trustManager = (SpiffeTrustManager) trustManagers[0];
         SpiffeIdVerifier spiffeIdVerifier = getSpiffeIdVerifier(trustManager);
-        assertTrue(spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/" + UUID.randomUUID()), null));
+        assertDoesNotThrow(() -> spiffeIdVerifier.verify(SpiffeId.parse("spiffe://example.org/" + UUID.randomUUID()), null));
     }
 
     @Test

--- a/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeTrustManagerTest.java
+++ b/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeTrustManagerTest.java
@@ -3,6 +3,7 @@ package io.spiffe.provider;
 import io.spiffe.bundle.BundleSource;
 import io.spiffe.bundle.x509bundle.X509Bundle;
 import io.spiffe.exception.BundleNotFoundException;
+import io.spiffe.internal.CertificateUtils;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.spiffeid.TrustDomain;
 import lombok.val;
@@ -337,8 +338,13 @@ public class SpiffeTrustManagerTest {
         when(bundleSource.getBundleForTrustDomain(TrustDomain.of("example.org"))).thenReturn(bundleKnown);
         final SpiffeId expected = SpiffeId.parse("spiffe://example.org/test");
         final AtomicBoolean verifyResult = new AtomicBoolean(true);
-        final SpiffeIdVerifier verifier = spiffeId -> {
+        final SpiffeIdVerifier verifier = (spiffeId, chain) -> {
             assertEquals(expected, spiffeId);
+            try {
+                assertEquals(expected, CertificateUtils.getSpiffeId(chain[0]));
+            } catch (CertificateException e) {
+                fail(e);
+            }
             return verifyResult.get();
         };
 

--- a/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeTrustManagerTest.java
+++ b/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeTrustManagerTest.java
@@ -345,12 +345,12 @@ public class SpiffeTrustManagerTest {
             } catch (CertificateException e) {
                 fail(e);
             }
-            return verifyResult.get();
+            if (!verifyResult.get()) {
+                throw new SpiffeVerificationException("Stub failure.");
+            }
         };
 
         SpiffeTrustManager spiffeTrustManager = new SpiffeTrustManager(bundleSource, verifier);
-
-        verifyResult.set(true);
         try {
             spiffeTrustManager.checkServerTrusted(chain, "");
         } catch (CertificateException e) {
@@ -362,7 +362,7 @@ public class SpiffeTrustManagerTest {
             spiffeTrustManager.checkServerTrusted(chain, "");
             fail("CertificateException was expected");
         } catch (CertificateException e) {
-            assertEquals("SPIFFE ID spiffe://example.org/test in X.509 certificate is not accepted", e.getMessage());
+            assertEquals("Stub failure.", e.getMessage());
         }
     }
 


### PR DESCRIPTION
Rather than needing to know acceptable SPIFFE IDs in advance, this PR creates a mechanism by which applications can supply custom logic in a callback to verify if a SPIFFE ID is acceptable. For example, an application might decode the URI into some sort of structured data and check that a particular field matches the expected value. Or if the SPIFFE ID represents an opaque identifier this gives the application the option to lookup additional data about the identity in an external system and utilize that data.