### PR TITLE
Add FetchJWTSVIDs function for workloadapi and jwtSource

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvidSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvidSource.java
@@ -2,6 +2,9 @@ package io.spiffe.svid.jwtsvid;
 
 import io.spiffe.exception.JwtSvidException;
 import io.spiffe.spiffeid.SpiffeId;
+import lombok.NonNull;
+
+import java.util.List;
 
 /**
  * Represents a source of SPIFFE JWT-SVIDs.
@@ -28,4 +31,25 @@ public interface JwtSvidSource {
      * @throws JwtSvidException when there is an error fetching the JWT SVID
      */
     JwtSvid fetchJwtSvid(SpiffeId subject, String audience, String... extraAudiences) throws JwtSvidException;
+
+    /**
+     * Fetches all SPIFFE JWT-SVIDs on one-shot blocking call.
+     *
+     * @param audience      the audience of the JWT-SVID
+     * @param extraAudience the extra audience for the JWT_SVID
+     * @return all of {@link JwtSvid} object
+     * @throws JwtSvidException if there is an error fetching or processing the JWT from the Workload API
+     */
+    List<JwtSvid> fetchJwtSvids(@NonNull String audience, String... extraAudience) throws JwtSvidException;
+
+    /**
+     * Fetches all SPIFFE JWT-SVIDs on one-shot blocking call.
+     *
+     * @param subject       a SPIFFE ID
+     * @param audience      the audience of the JWT-SVID
+     * @param extraAudience the extra audience for the JWT_SVID
+     * @return all of {@link JwtSvid} object
+     * @throws JwtSvidException if there is an error fetching or processing the JWT from the Workload API
+     */
+    List<JwtSvid> fetchJwtSvids(@NonNull SpiffeId subject, @NonNull String audience, String... extraAudience) throws JwtSvidException;
 }

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/DefaultJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/DefaultJwtSource.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
+import java.util.List;
 
 import static io.spiffe.workloadapi.internal.ThreadUtils.await;
 
@@ -128,6 +129,30 @@ public class DefaultJwtSource implements JwtSource {
         }
 
         return workloadApiClient.fetchJwtSvid(subject, audience, extraAudiences);
+    }
+
+    @Override
+    public List<JwtSvid> fetchJwtSvids(String audience, String... extraAudiences) throws JwtSvidException {
+        if (isClosed()) {
+            throw new IllegalStateException("JWT SVID source is closed");
+        }
+        return workloadApiClient.fetchJwtSvids(audience, extraAudiences);
+    }
+
+    /**
+     * Fetches all new JWT SVIDs from the Workload API for the given subject SPIFFE ID and audiences.
+     *
+     * @return all {@link JwtSvid}s
+     * @throws IllegalStateException if the source is closed
+     */
+    @Override
+    public List<JwtSvid> fetchJwtSvids(final SpiffeId subject, final String audience, final String... extraAudiences)
+            throws JwtSvidException {
+        if (isClosed()) {
+            throw new IllegalStateException("JWT SVID source is closed");
+        }
+
+        return workloadApiClient.fetchJwtSvids(subject, audience, extraAudiences);
     }
 
     /**

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/WorkloadApiClient.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/WorkloadApiClient.java
@@ -11,6 +11,7 @@ import io.spiffe.svid.jwtsvid.JwtSvid;
 import lombok.NonNull;
 
 import java.io.Closeable;
+import java.util.List;
 
 /**
  * Represents a client to interact with the Workload API.
@@ -77,6 +78,27 @@ public interface WorkloadApiClient extends Closeable {
      * @throws JwtSvidException if there is an error fetching or processing the JWT from the Workload API
      */
     JwtSvid fetchJwtSvid(@NonNull SpiffeId subject, @NonNull String audience, String... extraAudience) throws JwtSvidException;
+
+    /**
+     * Fetches all SPIFFE JWT-SVIDs on one-shot blocking call.
+     *
+     * @param audience      the audience of the JWT-SVID
+     * @param extraAudience the extra audience for the JWT_SVID
+     * @return all of {@link JwtSvid} object
+     * @throws JwtSvidException if there is an error fetching or processing the JWT from the Workload API
+     */
+    List<JwtSvid> fetchJwtSvids(@NonNull String audience, String... extraAudience) throws JwtSvidException;
+
+    /**
+     * Fetches a SPIFFE JWT-SVID on one-shot blocking call.
+     *
+     * @param subject       a SPIFFE ID
+     * @param audience      the audience of the JWT-SVID
+     * @param extraAudience the extra audience for the JWT_SVID
+     * @return all of {@link JwtSvid} objectÏ
+     * @throws JwtSvidException if there is an error fetching or processing the JWT from the Workload API
+     */
+    List<JwtSvid> fetchJwtSvids(@NonNull SpiffeId subject, @NonNull String audience, String... extraAudience) throws JwtSvidException;
 
     /**
      * Fetches the JWT bundles for JWT-SVID validation, keyed by trust domain.

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientEmptyResponseTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientEmptyResponseTest.java
@@ -117,6 +117,28 @@ class DefaultWorkloadApiClientEmptyResponseTest {
     }
 
     @Test
+    void testFetchJwtSvids_throwsJwtSvidException() {
+        try {
+            workloadApiClient.fetchJwtSvids("aud1", "aud2");
+            fail();
+        } catch (JwtSvidException e) {
+            assertEquals("Error fetching JWT SVID", e.getMessage());
+            assertEquals("JWT SVID response from the Workload API is empty", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidsPassingSpiffeId_throwsJwtSvidException() {
+        try {
+            workloadApiClient.fetchJwtSvids(SpiffeId.parse("spiffe://example.org/test"), "aud1", "aud2");
+            fail();
+        } catch (JwtSvidException e) {
+            assertEquals("Error fetching JWT SVID", e.getMessage());
+            assertEquals("JWT SVID response from the Workload API is empty", e.getCause().getMessage());
+        }
+    }
+
+    @Test
     void testValidateJwtSvid_throwsJwtSvidException() {
         try {
             workloadApiClient.validateJwtSvid("token", "aud1");

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientInvalidArgumentTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientInvalidArgumentTest.java
@@ -116,6 +116,26 @@ class DefaultWorkloadApiClientInvalidArgumentTest {
     }
 
     @Test
+    void testFetchJwtSvids_throwsJwtSvidException() {
+        try {
+            workloadApiClient.fetchJwtSvids("aud1", "aud2");
+            fail();
+        } catch (JwtSvidException e) {
+            assertEquals("Error fetching JWT SVID", e.getMessage());
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidsPassingSpiffeId_throwsJwtSvidException() {
+        try {
+            workloadApiClient.fetchJwtSvids(SpiffeId.parse("spiffe://example.org/test"), "aud1", "aud2");
+            fail();
+        } catch (JwtSvidException e) {
+            assertEquals("Error fetching JWT SVID", e.getMessage());
+        }
+    }
+
+    @Test
     void testValidateJwtSvid_throwsJwtSvidException() {
         try {
             workloadApiClient.validateJwtSvid("token", "aud1");

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientTest.java
@@ -280,6 +280,74 @@ class DefaultWorkloadApiClientTest {
     }
 
     @Test
+    void testFetchJwtSvids() {
+        try {
+            List<JwtSvid> jwtSvids = workloadApiClient.fetchJwtSvids("aud1", "aud2", "aud3");
+            System.out.println(jwtSvids.toString());
+            assertNotNull(jwtSvids);
+            assertEquals(jwtSvids.size(), 2);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), jwtSvids.get(0).getSpiffeId());
+            assertTrue(jwtSvids.get(0).getAudience().contains("aud1"));
+            assertEquals(3, jwtSvids.get(0).getAudience().size());
+            assertEquals(SpiffeId.parse("spiffe://example.org/extra-workload-server"), jwtSvids.get(1).getSpiffeId());
+            assertTrue(jwtSvids.get(1).getAudience().contains("aud1"));
+            assertEquals(3, jwtSvids.get(1).getAudience().size());
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidsPassingSpiffeId() {
+        try {
+            List<JwtSvid> jwtSvids = workloadApiClient.fetchJwtSvids(SpiffeId.parse("spiffe://example.org/test"), "aud1", "aud2", "aud3");
+            assertNotNull(jwtSvids);
+            assertEquals(jwtSvids.size(), 1);
+            assertEquals(SpiffeId.parse("spiffe://example.org/test"), jwtSvids.get(0).getSpiffeId());
+            assertTrue(jwtSvids.get(0).getAudience().contains("aud1"));
+            assertEquals(3, jwtSvids.get(0).getAudience().size());
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvids_nullAudience() {
+        try {
+            workloadApiClient.fetchJwtSvid(null, new String[]{"aud2", "aud3"});
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("audience is marked non-null but is null", e.getMessage());
+        } catch (JwtSvidException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void testFetchJwtSvids_withSpiffeIdAndNullAudience() {
+        try {
+            workloadApiClient.fetchJwtSvid(SpiffeId.parse("spiffe://example.org/text"), null, "aud2", "aud3");
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("audience is marked non-null but is null", e.getMessage());
+        } catch (JwtSvidException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void testFetchJwtSvids_nullSpiffeId() {
+        try {
+            workloadApiClient.fetchJwtSvid(null, "aud1", new String[]{"aud2", "aud3"});
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("subject is marked non-null but is null", e.getMessage());
+        } catch (JwtSvidException e) {
+            fail();
+        }
+    }
+
+    @Test
     void testValidateJwtSvid() {
         String token = generateToken("spiffe://example.org/workload-server", Collections.singletonList("aud1"));
         try {

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientErrorStub.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientErrorStub.java
@@ -11,6 +11,7 @@ import io.spiffe.svid.jwtsvid.JwtSvid;
 import lombok.NonNull;
 
 import java.io.IOException;
+import java.util.List;
 
 public class WorkloadApiClientErrorStub implements WorkloadApiClient {
 
@@ -41,6 +42,16 @@ public class WorkloadApiClientErrorStub implements WorkloadApiClient {
 
     @Override
     public JwtSvid fetchJwtSvid(@NonNull final SpiffeId subject, @NonNull final String audience, final String... extraAudience) throws JwtSvidException {
+        throw new JwtSvidException("Testing exception");
+    }
+
+    @Override
+    public List<JwtSvid> fetchJwtSvids(@NonNull String audience, String... extraAudience) throws JwtSvidException {
+        throw new JwtSvidException("Testing exception");
+    }
+
+    @Override
+    public List<JwtSvid> fetchJwtSvids(@NonNull SpiffeId subject, @NonNull String audience, String... extraAudience) throws JwtSvidException {
         throw new JwtSvidException("Testing exception");
     }
 

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientStub.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientStub.java
@@ -23,14 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static io.spiffe.utils.TestUtils.toUri;
 
@@ -41,6 +34,7 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
     final String x509Bundle = "testdata/workloadapi/bundle.der";
     final String jwtBundle = "testdata/workloadapi/bundle.json";
     final SpiffeId subject = SpiffeId.parse("spiffe://example.org/workload-server");
+    final SpiffeId extraSubject = SpiffeId.parse("spiffe://example.org/extra-workload-server");
 
     boolean closed;
 
@@ -74,6 +68,21 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
     @Override
     public JwtSvid fetchJwtSvid(@NonNull final SpiffeId subject, @NonNull final String audience, final String... extraAudience) throws JwtSvidException {
         return generateJwtSvid(subject, audience, extraAudience);
+    }
+
+    @Override
+    public List<JwtSvid> fetchJwtSvids(@NonNull String audience, String... extraAudience) throws JwtSvidException {
+        List<JwtSvid> svids = new ArrayList<>();
+        svids.add(generateJwtSvid(subject, audience, extraAudience));
+        svids.add(generateJwtSvid(extraSubject, audience, extraAudience));
+        return svids;
+    }
+
+    @Override
+    public List<JwtSvid> fetchJwtSvids(@NonNull SpiffeId subject, @NonNull String audience, String... extraAudience) throws JwtSvidException {
+        List<JwtSvid> svids = new ArrayList<>();
+        svids.add(generateJwtSvid(subject, audience, extraAudience));
+        return svids;
     }
 
     @Override

--- a/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientErrorStub.java
+++ b/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientErrorStub.java
@@ -13,6 +13,7 @@ import io.spiffe.workloadapi.WorkloadApiClient;
 import io.spiffe.workloadapi.X509Context;
 import lombok.NonNull;
 
+import java.util.List;
 import java.io.IOException;
 
 public class WorkloadApiClientErrorStub implements WorkloadApiClient {
@@ -46,7 +47,15 @@ public class WorkloadApiClientErrorStub implements WorkloadApiClient {
     public JwtSvid fetchJwtSvid(@NonNull final SpiffeId subject, @NonNull final String audience, final String... extraAudience) throws JwtSvidException {
         throw new JwtSvidException("Testing exception");
     }
+    @Override
+    public List<JwtSvid> fetchJwtSvids(@NonNull final String audience, final String... extraAudience) throws JwtSvidException {
+        throw new JwtSvidException("Testing exception");
+    }
 
+    @Override
+    public List<JwtSvid> fetchJwtSvids(@NonNull final SpiffeId subject, @NonNull final String audience, final String... extraAudience) throws JwtSvidException {
+        throw new JwtSvidException("Testing exception");
+    }
     @Override
     public JwtBundleSet fetchJwtBundles() throws JwtBundleException {
         throw new JwtBundleException("Testing exception");

--- a/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientStub.java
+++ b/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientStub.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Collections;
 
 public class WorkloadApiClientStub implements WorkloadApiClient {
@@ -64,6 +65,15 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
         return null;
     }
 
+    @Override
+    public List<JwtSvid> fetchJwtSvids(@NonNull String audience, String... extraAudience) throws JwtSvidException {
+        return null;
+    }
+
+    @Override
+    public List<JwtSvid> fetchJwtSvids(@NonNull final SpiffeId subject, @NonNull final String audience, final String... extraAudience) throws JwtSvidException {
+        return null;
+    }
     @Override
     public JwtBundleSet fetchJwtBundles() throws JwtBundleException {
         return null;


### PR DESCRIPTION
Signed-off-by: Yuhan Li [liyuhan.loveyana@bytedance.com](mailto:liyuhan.loveyana@bytedance.com)

Add fetchJWTSVIDs method for workloadapi and jwtsource to fetch all jwt-svids, which are provided to the client side for filtering under workload scenarios with multiple registration information.

Related: https://github.com/spiffe/go-spiffe/pull/187, https://github.com/HewlettPackard/py-spiffe/pull/105