### PR TITLE
lower verbosity of Successful JwtBundleSet refresh

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/DefaultJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/DefaultJwtSource.java
@@ -211,7 +211,7 @@ public class DefaultJwtSource implements JwtSource {
         workloadApiClient.watchJwtBundles(new Watcher<JwtBundleSet>() {
             @Override
             public void onUpdate(final JwtBundleSet update) {
-                log.log(Level.INFO, "Received JwtBundleSet update");
+                log.log(Level.DEBUG, "Received JwtBundleSet update");
                 setJwtBundleSet(update);
                 done.countDown();
             }


### PR DESCRIPTION
this is a bit spew-y, I really only care if the update fails which logs separately.