### PR TITLE
Update grpc-java dependency to 1.49.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ subprojects {
     version = '0.8.0'
 
     ext {
-        grpcVersion = '1.46.0'
+        grpcVersion = '1.49.0'
         jupiterVersion = '5.7.0'
         mockitoVersion = '3.5.15'
         lombokVersion = '1.18.20'

--- a/java-spiffe-core/grpc-netty-macos/build.gradle
+++ b/java-spiffe-core/grpc-netty-macos/build.gradle
@@ -2,7 +2,7 @@ description = "Java SPIFFE Library GRPC-Netty MacOS module"
 
 dependencies {
     implementation group: 'io.grpc', name: 'grpc-netty', version: "${grpcVersion}"
-    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.63.Final', classifier: 'osx-x86_64'
+    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.79.Final', classifier: 'osx-x86_64'
 }
 
 jar {


### PR DESCRIPTION
Also it was needed to updated the dependency `netty-transport-native-kqueue` to be able to compile on MacOs with the new grpc-java version.

Signed-off-by: Max Lambrecht <max.lambrecht@hpe.com>