### PR TITLE
Update gradle version to 8.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,9 @@ subprojects {
         testCompileOnly group: 'org.mockito', name: 'mockito-core', version: "${mockitoVersion}"
         testRuntimeOnly group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockitoVersion}"
 
+        testImplementation group: 'uk.org.webcompere', name: 'system-stubs-core', version: '2.0.2'
+        testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.1.1'
+
         // Project Lombok dependency
         compileOnly group: 'org.projectlombok', name: 'lombok', version: "${lombokVersion}"
         annotationProcessor group: 'org.projectlombok', name: 'lombok', version: "${lombokVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ subprojects {
 
     ext {
         grpcVersion = '1.51.1'
-        jupiterVersion = '5.7.0'
-        mockitoVersion = '3.5.15'
+        jupiterVersion = '5.9.2'
+        mockitoVersion = '3.12.4'
         lombokVersion = '1.18.20'
         nimbusVersion = '9.28'
 
@@ -148,8 +148,8 @@ task jacocoTestReport(type: JacocoReport) {
     }
 
     reports {
-        xml.enabled true
-        html.enabled true
+        xml.required = true
+        html.required = true
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ subprojects {
         mockitoVersion = '3.12.4'
         lombokVersion = '1.18.20'
         nimbusVersion = '9.31'
+        shadowVersion = '8.1.1'
 
         //IMPORTANT: This must be in sync with the shaded netty version in gRPC
         nettyVersion = '4.1.91.Final'

--- a/build.gradle
+++ b/build.gradle
@@ -107,9 +107,9 @@ subprojects {
 
         testCompileOnly group: 'org.mockito', name: 'mockito-core', version: "${mockitoVersion}"
         testRuntimeOnly group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockitoVersion}"
+        testRuntimeOnly group: 'org.mockito', name: 'mockito-inline', version: "${mockitoVersion}"
 
         testImplementation group: 'uk.org.webcompere', name: 'system-stubs-core', version: '2.0.2'
-        testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.1.1'
 
         // Project Lombok dependency
         compileOnly group: 'org.projectlombok', name: 'lombok', version: "${lombokVersion}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip

--- a/java-spiffe-core/build.gradle
+++ b/java-spiffe-core/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath group: 'com.google.protobuf', name: 'protobuf-gradle-plugin', version: '0.8.13'
+        classpath group: 'com.google.protobuf', name: 'protobuf-gradle-plugin', version: '0.9.2'
     }
 }
 
@@ -30,6 +30,8 @@ sourceSets {
         resources.srcDir file('src/integrationTest/resources')
     }
 }
+
+sourcesJar.duplicatesStrategy = DuplicatesStrategy.INCLUDE
 
 configurations {
     integrationTestImplementation.extendsFrom testImplementation

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/AddressTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/AddressTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 import java.net.URI;
 import java.util.stream.Stream;
@@ -74,19 +75,24 @@ public class AddressTest {
 
     @Test
     void getDefaultAddress() throws Exception {
-        TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test" );
-        String defaultAddress = Address.getDefaultAddress();
-        assertEquals("unix:/tmp/test", defaultAddress);
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test").execute(() -> {
+            String defaultAddress = Address.getDefaultAddress();
+            assertEquals("unix:/tmp/test", defaultAddress);
+        });
     }
 
     @Test
     void getDefaultAddress_isBlankThrowsException() throws Exception {
-        TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "");
-        try {
-            Address.getDefaultAddress();
-            fail();
-        } catch (Exception e) {
-            assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
-        }
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "").execute(() -> {
+            try {
+                Address.getDefaultAddress();
+                fail();
+            } catch (Exception e) {
+                assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
+            }
+        });
+
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "").execute(() -> {
+        });
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
@@ -14,6 +14,7 @@ import lombok.val;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 import java.io.IOException;
 import java.time.Clock;
@@ -495,28 +496,29 @@ class CachedJwtSourceTest {
 
     @Test
     void newSource_DefaultSocketAddress() throws Exception {
-        try {
-            TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test");
-            DefaultJwtSource.newSource();
-            fail();
-        } catch (JwtSourceException e) {
-            assertEquals("Error creating JWT source", e.getMessage());
-        } catch (SocketEndpointAddressException e) {
-            fail();
-        }
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test").execute(() -> {
+            try {
+                CachedJwtSource.newSource();
+                fail();
+            } catch (JwtSourceException e) {
+                assertEquals("Error creating JWT source", e.getMessage());
+            } catch (SocketEndpointAddressException e) {
+                fail();
+            }
+        });
     }
 
     @Test
     void newSource_noSocketAddress() throws Exception {
-        try {
-            // just in case it's defined in the environment
-            TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "");
-            DefaultJwtSource.newSource();
-            fail();
-        } catch (SocketEndpointAddressException e) {
-            fail();
-        } catch (IllegalStateException e) {
-            assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
-        }
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "").execute(() -> {
+            try {
+                CachedJwtSource.newSource();
+                fail();
+            } catch (SocketEndpointAddressException e) {
+                fail();
+            } catch (IllegalStateException e) {
+                assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
+            }
+        });
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
@@ -9,7 +9,6 @@ import io.spiffe.exception.SocketEndpointAddressException;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.spiffeid.TrustDomain;
 import io.spiffe.svid.jwtsvid.JwtSvid;
-import io.spiffe.utils.TestUtils;
 import lombok.val;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultJwtSourceTest.java
@@ -254,7 +254,6 @@ class DefaultJwtSourceTest {
         }
     }
 
-
     @Test
     void newSource_DefaultSocketAddress() throws Exception {
         new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test").execute(() -> {

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientTest.java
@@ -20,6 +20,7 @@ import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 import java.io.IOException;
 import java.security.KeyPair;
@@ -54,13 +55,14 @@ class DefaultWorkloadApiClientTest {
 
     @Test
     void testNewClient_defaultOptions() throws Exception {
-        try {
-            TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/agent.sock" );
-            WorkloadApiClient client = DefaultWorkloadApiClient.newClient();
-            assertNotNull(client);
-        } catch (SocketEndpointAddressException e) {
-            fail(e);
-        }
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/agent.sock").execute(() -> {
+            try {
+                WorkloadApiClient client = DefaultWorkloadApiClient.newClient();
+                assertNotNull(client);
+            } catch (SocketEndpointAddressException e) {
+                fail(e);
+            }
+        });
     }
 
     @Test

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
@@ -12,6 +12,7 @@ import lombok.val;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 import java.time.Duration;
 
@@ -160,15 +161,15 @@ class DefaultX509SourceTest {
 
     @Test
     void newSource_noSocketAddress() throws Exception {
-        try {
-            // just in case the variable is defined in the environment
-            TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "");
-            DefaultX509Source.newSource();
-            fail();
-        } catch (X509SourceException | SocketEndpointAddressException e) {
-            fail();
-        } catch (IllegalStateException e) {
-            assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
-        }
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "").execute(() -> {
+            try {
+                DefaultX509Source.newSource();
+                fail();
+            } catch (X509SourceException | SocketEndpointAddressException e) {
+                fail();
+            } catch (IllegalStateException e) {
+                assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
+            }
+        });
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
@@ -7,7 +7,6 @@ import io.spiffe.exception.X509SourceException;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.spiffeid.TrustDomain;
 import io.spiffe.svid.x509svid.X509Svid;
-import io.spiffe.utils.TestUtils;
 import lombok.val;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/JwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/JwtSourceTest.java
@@ -14,6 +14,7 @@ import lombok.val;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -253,30 +254,32 @@ class JwtSourceTest {
         }
     }
 
+
     @Test
     void newSource_DefaultSocketAddress() throws Exception {
-        try {
-            TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test");
-            DefaultJwtSource.newSource();
-            fail();
-        } catch (JwtSourceException e) {
-            assertEquals("Error creating JWT source", e.getMessage());
-        } catch (SocketEndpointAddressException e) {
-            fail();
-        }
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test").execute(() -> {
+            try {
+                DefaultJwtSource.newSource();
+                fail();
+            } catch (JwtSourceException e) {
+                assertEquals("Error creating JWT source", e.getMessage());
+            } catch (SocketEndpointAddressException e) {
+                fail();
+            }
+        });
     }
 
     @Test
     void newSource_noSocketAddress() throws Exception {
-        try {
-            // just in case it's defined in the environment
-            TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "");
-            DefaultJwtSource.newSource();
-            fail();
-        } catch (SocketEndpointAddressException e) {
-            fail();
-        } catch (IllegalStateException e) {
-            assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
-        }
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "").execute(() -> {
+            try {
+                DefaultJwtSource.newSource();
+                fail();
+            } catch (SocketEndpointAddressException e) {
+                fail();
+            } catch (IllegalStateException e) {
+                assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
+            }
+        });
     }
 }

--- a/java-spiffe-core/src/testFixtures/java/io/spiffe/utils/TestUtils.java
+++ b/java-spiffe-core/src/testFixtures/java/io/spiffe/utils/TestUtils.java
@@ -106,38 +106,7 @@ public class TestUtils {
                 .build();
     }
 
-    public static void setEnvironmentVariable(String variableName, String value) throws Exception {
-        Class<?> processEnvironment = Class.forName("java.lang.ProcessEnvironment");
-
-        Field unmodifiableMapField = getField(processEnvironment, "theUnmodifiableEnvironment");
-        Object unmodifiableMap = unmodifiableMapField.get(null);
-        injectIntoUnmodifiableMap(variableName, value, unmodifiableMap);
-
-        Field mapField = getField(processEnvironment, "theEnvironment");
-        Map<String, String> map = (Map<String, String>) mapField.get(null);
-        map.put(variableName, value);
-    }
-
-    public static Object invokeMethod(Class<?> clazz, String methodName, Object... args) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Method method = clazz.getDeclaredMethod(methodName);
-        method.setAccessible(true);
-        return method.invoke(args);
-    }
-
-    public static Field getField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
-        Field field = clazz.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        return field;
-    }
-
     public static URI toUri(String path) throws URISyntaxException {
         return Thread.currentThread().getContextClassLoader().getResource(path).toURI();
-    }
-
-    private static void injectIntoUnmodifiableMap(String key, String value, Object map) throws ReflectiveOperationException {
-        Class unmodifiableMap = Class.forName("java.util.Collections$UnmodifiableMap");
-        Field field = getField(unmodifiableMap, "m");
-        Object obj = field.get(map);
-        ((Map<String, String>) obj).put(key, value);
     }
 }

--- a/java-spiffe-helper/build.gradle
+++ b/java-spiffe-helper/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "com.github.johnrengelman.shadow" version "${shadowVersion}"
 }
 
 description = "Java SPIFFE Library Helper module to store X.509 SVIDs and Bundles in a Java KeyStore in disk"

--- a/java-spiffe-helper/build.gradle
+++ b/java-spiffe-helper/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "5.2.0"
+    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 description = "Java SPIFFE Library Helper module to store X.509 SVIDs and Bundles in a Java KeyStore in disk"

--- a/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/KeyStoreHelperTest.java
+++ b/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/KeyStoreHelperTest.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -190,13 +191,14 @@ class KeyStoreHelperTest {
 
     @Test
     void testCreateKeyStoreHelper_createNewClient() throws Exception {
-        TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test");
-        val options = getKeyStoreValidOptions(null);
-        try {
-            KeyStoreHelper.create(options);
-        } catch (KeyStoreHelperException e) {
-            fail();
-        }
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test").execute(() -> {
+            val options = getKeyStoreValidOptions(null);
+            try {
+                KeyStoreHelper.create(options);
+            } catch (KeyStoreHelperException e) {
+                fail();
+            }
+        });
     }
 
     @Test

--- a/java-spiffe-provider/build.gradle
+++ b/java-spiffe-provider/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "com.github.johnrengelman.shadow" version "${shadowVersion}"
 }
 
 description = "Java Security Provider implementation supporting X.509-SVIDs and methods for " +

--- a/java-spiffe-provider/build.gradle
+++ b/java-spiffe-provider/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "5.2.0"
+    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 description = "Java Security Provider implementation supporting X.509-SVIDs and methods for " +

--- a/java-spiffe-provider/src/test/java/io/spiffe/provider/X509SourceManagerTest.java
+++ b/java-spiffe-provider/src/test/java/io/spiffe/provider/X509SourceManagerTest.java
@@ -4,6 +4,7 @@ import io.spiffe.utils.TestUtils;
 import io.spiffe.workloadapi.Address;
 import io.spiffe.workloadapi.X509Source;
 import org.junit.jupiter.api.Test;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 import java.lang.reflect.Field;
 
@@ -24,11 +25,12 @@ class X509SourceManagerTest {
 
     @Test
     void getX509Source_defaultAddressNotSet() throws Exception {
-        TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "" );
-        try {
-            X509SourceManager.getX509Source();
-        } catch (IllegalStateException e) {
-            assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
-        }
+        new EnvironmentVariables(Address.SOCKET_ENV_VARIABLE, "").execute(() -> {
+            try {
+                X509SourceManager.getX509Source();
+            } catch (IllegalStateException e) {
+                assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
+            }
+        });
     }
 }


### PR DESCRIPTION
Also added dependency `system-stubs` to set environment variables in tests. (Fixing issue running tests in JDK 16 which has limits on java reflection preventing the setting of environment variables in the tests running context).

Signed-off-by: Max Lambrecht <max.lambrecht@hpe.com>