### PR TITLE
Add default constructor to SpiffeSslSocketFactory

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/spiffeid/SpiffeIdUtils.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/spiffeid/SpiffeIdUtils.java
@@ -21,7 +21,7 @@ public final class SpiffeIdUtils {
 
     private static final char DEFAULT_CHAR_SEPARATOR = '|';
 
-    private static final Set<Character> SUPPORTED_SEPARATORS = Sets.newHashSet(DEFAULT_CHAR_SEPARATOR, ' ');
+    private static final Set<Character> SUPPORTED_SEPARATORS = Sets.newHashSet(DEFAULT_CHAR_SEPARATOR, ' ', ',');
 
     private SpiffeIdUtils() {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");

--- a/java-spiffe-core/src/test/java/io/spiffe/spiffeid/SpiffeIdUtilsTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/spiffeid/SpiffeIdUtilsTest.java
@@ -71,14 +71,14 @@ class SpiffeIdUtilsTest {
     }
 
     @Test
-    void toSetOfSpiffeIdsInvalidSeparator() {
-        val spiffeIdsAsString = "spiffe://example.org/workload1, spiffe://example.org/workload2";
-        try {
-            SpiffeIdUtils.toSetOfSpiffeIds(spiffeIdsAsString, ',');
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertEquals("Separator character is not supported.", e.getMessage());
-        }
+    void toSetOfSpiffeIdsCommaSeparator() {
+        val spiffeIdsAsString = "spiffe://example.org/workload1,spiffe://example.org/workload2";
+        val spiffeIdSet = SpiffeIdUtils.toSetOfSpiffeIds(spiffeIdsAsString, ',');
+
+        assertNotNull(spiffeIdSet);
+        assertEquals(2, spiffeIdSet.size());
+        assertTrue(spiffeIdSet.contains(SpiffeId.parse("spiffe://example.org/workload1")));
+        assertTrue(spiffeIdSet.contains(SpiffeId.parse("spiffe://example.org/workload2")));
     }
 
     @Test

--- a/java-spiffe-provider/README.md
+++ b/java-spiffe-provider/README.md
@@ -141,10 +141,10 @@ export SPIFFE_ENDPOINT_SOCKET=/tmp/agent.sock
 
 A Java app can connect to a Postgres DB using TLS and authenticate itself using certificates provided by SPIRE through
 the SPIFFE Workload API. To enable this functionality, there's a custom `SSLSocketFactory` implementation that injects a 
-custom `SSLContext` that uses the SPIFFE `KeyStore` and a `Truststore` implementations to obtain certificates and bundles
+custom `SSLContext` that uses the SPIFFE `KeyStore` and a `TrustStore` implementations to obtain certificates and bundles
 from a SPIRE Agent, keep them updated in memory, and provide them for TLS connections.
 
-The URL to connect to Postgress using TLS and Java SPIFFE is as follows:
+The URL to connect to Postgres using TLS and Java SPIFFE is as follows:
 
 ```
 jdbc:postgresql://localhost:5432/postgres?sslmode=require&sslfactory=io.spiffe.provider.SpiffeSslSocketFactory

--- a/java-spiffe-provider/README.md
+++ b/java-spiffe-provider/README.md
@@ -137,6 +137,35 @@ export SPIFFE_ENDPOINT_SOCKET=/tmp/agent.sock
 
 ## Use Cases
 
+### Connect to Postgres DB using TLS and the SPIFFE SslSocketFactory 
+
+A Java app can connect to a Postgres DB using TLS and authenticate itself using certificates provided by SPIRE through
+the SPIFFE Workload API. To enable this functionality, there's a custom `SSLSocketFactory` implementation that injects a 
+custom `SSLContext` that uses the SPIFFE `KeyStore` and a `Truststore` implementations to obtain certificates and bundles
+from a SPIRE Agent, keep them updated in memory, and provide them for TLS connections.
+
+The URL to connect to Postgress using TLS and Java SPIFFE is as follows:
+
+```
+jdbc:postgresql://localhost:5432/postgres?sslmode=require&sslfactory=io.spiffe.provider.SpiffeSslSocketFactory
+```
+
+The parameter `sslfactory` in the URL configures the Postgres JDBC driver to use the `SpiffeSslSocketFactory` which wraps 
+around an SSL Socket with the Java SPIFFE functionality.
+
+The Workload API socket endpoint should be configured through the Environment variable `SPIFFE_ENDPOINT_SOCKET`.
+
+During the connection to a Postgres DB, the server presents its certificate, which is validated using trust bundles
+obtained from the SPIFFE Workload API. 
+To also validate that the SPIFFE ID presented in the server's certificate is one of a list of expected SPIFFE IDs, 
+the property `ssl.spiffe.accept` needs to be configured with the expected SPIFFE IDs separated by commas.  
+For example:
+
+```
+-Dssl.spiffe.accept=spiffe://domain.test/db-1,spiffe://domain.test/db-2'
+```
+If this property is not configured, any SPIFFE ID will be accepted in a TLS connection.
+
 ### Configure a Tomcat connector
 
 ***Prerequisite***: Having the SPIFFE Provider configured through the `java.security`.

--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeSslSocketFactory.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeSslSocketFactory.java
@@ -1,22 +1,76 @@
 package io.spiffe.provider;
 
+import io.spiffe.exception.SocketEndpointAddressException;
+import io.spiffe.exception.X509SourceException;
 import io.spiffe.provider.SpiffeSslContextFactory.SslContextOptions;
+import io.spiffe.spiffeid.SpiffeId;
+import io.spiffe.spiffeid.SpiffeIdUtils;
+import io.spiffe.workloadapi.DefaultX509Source;
+import io.spiffe.workloadapi.X509Source;
+import lombok.extern.java.Log;
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+import static io.spiffe.provider.SpiffeProviderConstants.SSL_SPIFFE_ACCEPT_PROPERTY;
 
 /**
  * Implementation of {@link SSLSocketFactory} that provides methods to create {@link javax.net.ssl.SSLSocket}
  * backed by a SPIFFE SSLContext {@link SpiffeSslContextFactory}.
  */
+@Log
 public class SpiffeSslSocketFactory extends SSLSocketFactory {
 
     private final SSLSocketFactory delegate;
+
+    /**
+     * Default Constructor.
+     *
+     * This SpiffeSslSocketFactory is backed by SPIFFE-aware SSLContext that obtains certificates
+     * from the SPIFFE Workload API, connecting to a socket configured through the environment variable
+     * 'SPIFFE_ENDPOINT_SOCKET'.
+     *
+     * The list of accepted SPIFFE IDs, that will be used to validate the SAN in a peer certificate,
+     * can be configured through the property 'ssl.spiffe.accept', separating the SPIFFE IDs using commas
+     * without spaces, e.g., '-Dssl.spiffe.accept=spiffe://domain.test/service,spiffe://example.org/app'
+     * If the property is not set, any SPIFFE ID will be accepted in a TLS connection.
+     *
+     * @throws NoSuchAlgorithmException if there is a problem creating the SSL context
+     * @throws KeyManagementException   if there is a problem initializing the SSL context
+     * @throws X509SourceException if there is a problem creating the source of X.509 certificates
+     * @throws SocketEndpointAddressException if there is a problem connecting to the local SPIFFE socket
+     *
+     */
+    public SpiffeSslSocketFactory() throws SocketEndpointAddressException, X509SourceException, NoSuchAlgorithmException, KeyManagementException {
+        log.log(Level.INFO, "Creating SpiffeSslSocketFactory");
+
+        SSLContext sslContext;
+        Supplier<Set<SpiffeId>> acceptedSpiffeIds;
+        SslContextOptions options;
+
+        X509Source x509source = DefaultX509Source.newSource();
+        String envProperty = EnvironmentUtils.getProperty(SSL_SPIFFE_ACCEPT_PROPERTY);
+
+        if (StringUtils.isNotBlank(envProperty)) {
+            acceptedSpiffeIds = () -> SpiffeIdUtils.toSetOfSpiffeIds(envProperty, ',');
+            options = SslContextOptions.builder().acceptedSpiffeIdsSupplier(acceptedSpiffeIds).x509Source(x509source).build();
+        } else {
+            options = SslContextOptions.builder().acceptAnySpiffeId().x509Source(x509source).build();
+        }
+
+        sslContext = SpiffeSslContextFactory.getSslContext(options);
+        delegate = sslContext.getSocketFactory();
+    }
 
     /**
      * Constructor.


### PR DESCRIPTION
This PR adds a constructor without parameters to `SpiffeSslSocketFactory` so it can be used in some scenarios where the default constructor is needed. For example: Postgress JDBC driver allows to provide a custom `SslSocketFactory` through the URL, like `jdbc:postgresql://db-server:5432/postgres?sslmode=require&sslfactory=io.spiffe.provider.SpiffeSslSocketFactory`.

Another change is to allow commas as separator in the list of expected SPIFFEs, so this list can be defined as java system property (`-Dssl.spiffe.accept=spiffe://domain.test/db-1,spiffe://domain.test/db-2'`). 
Originally commas wasn't allowed as a separator as they could be used as part of a SPIFFE ID, but that is not longer the case, a SPIFFE ID cannot contain a commas. 