### PR TITLE
Add config 'includeRootCaCertInChain' to java-spiffe-helper 

### DIFF
--- a/java-spiffe-helper/README.md
+++ b/java-spiffe-helper/README.md
@@ -10,11 +10,11 @@ The Helper automatically gets the SVID updates and stores them in the KeyStore a
 
 On Linux:
 
-`java -jar java-spiffe-helper-0.8.1-linux-x86_64.jar -c helper.conf`
+`java -jar java-spiffe-helper-0.7.0-linux-x86_64.jar -c helper.conf`
 
 On Mac OS:
 
-`java -jar java-spiffe-helper-0.8.1-osx-x86_64.jar -c helper.conf`
+`java -jar java-spiffe-helper-0.7.0-osx-x86_64.jar -c helper.conf`
 
 Either `-c` or `--config` should be used to pass the path to the config file.
 

--- a/java-spiffe-helper/README.md
+++ b/java-spiffe-helper/README.md
@@ -10,15 +10,13 @@ The Helper automatically gets the SVID updates and stores them in the KeyStore a
 
 On Linux:
 
-`java -jar java-spiffe-helper-0.7.0-linux-x86_64.jar -c helper.conf`
+`java -jar java-spiffe-helper-0.8.1-linux-x86_64.jar -c helper.conf`
 
 On Mac OS:
 
-`java -jar java-spiffe-helper-0.7.0-osx-x86_64.jar -c helper.conf`
+`java -jar java-spiffe-helper-0.8.1-osx-x86_64.jar -c helper.conf`
 
 Either `-c` or `--config` should be used to pass the path to the config file.
-
-(The jar can be downloaded from [Github releases](https://github.com/spiffe/java-spiffe/releases/tag/v0.7.0))
 
 ## Config file
 
@@ -34,21 +32,24 @@ keyStoreType = pkcs12
 
 keyAlias = spiffe
 
+includeRootCaCertInChain = true
+
 spiffeSocketPath = unix:/tmp/agent.sock
 ```
 
 ### Configuration Properties
 
- |Configuration     | Description                                                                    | Default value |
- |------------------|--------------------------------------------------------------------------------| ------------- |
- |`keyStorePath`    | Path to the Java KeyStore File for storing the Private Key and chain of certs  |     none      |
- |`keyStorePass`    | Password to protect the Java KeyStore File                                     |     none      |
- |`keyPass`         | Password to protect the Private Key entry in the KeyStore                      |     none      |
- |`trustStorePath`  | Path to the Java TrustStore File for storing the trusted bundles               |     none      |
- |`trustStorePass`  | Password to protect the Java TrustStore File                                   |     none      |
- |`keyStoreType`    | Java KeyStore Type. (`pkcs12` and `jks` are supported). Case insensitive.      |     pkcs12    |
- |`keyAlias`        | Alias for the Private Key entry                                                |     spiffe    |
- |`spiffeSocketPath`| Path the Workload API                                                          |     Read from the system variable: SPIFFE_ENDPOINT_SOCKET  |
+ | Configuration      | Description                                                                    | Default value |
+------------------------------|------------------|--------------------------------------------------------------------------------| ------------- |
+ | `keyStorePath`             | Path to the Java KeyStore File for storing the Private Key and chain of certs  |     none      |
+ | `keyStorePass`             | Password to protect the Java KeyStore File                                     |     none      |
+ | `keyPass`                  | Password to protect the Private Key entry in the KeyStore                      |     none      |
+ | `trustStorePath`           | Path to the Java TrustStore File for storing the trusted bundles               |     none      |
+ | `trustStorePass`           | Password to protect the Java TrustStore File                                   |     none      |
+ | `keyStoreType`             | Java KeyStore Type. (`pkcs12` and `jks` are supported). Case insensitive.      |     pkcs12    |
+ | `keyAlias`                 | Alias for the Private Key entry                                                |     spiffe    |
+ | `includeRootCaCertInChain` | Configures to include a self-signed CA certificate as part of the cert chain   |     false     |
+ | `spiffeSocketPath`         | Path the Workload API                                                          |     Read from the system variable: SPIFFE_ENDPOINT_SOCKET  |
   
 KeyStore and TrustStore **must** be in separate files. If `keyStorePath` and `trustStorePath` points to the same file, an error
 is shown

--- a/java-spiffe-helper/src/main/java/io/spiffe/helper/cli/Config.java
+++ b/java-spiffe-helper/src/main/java/io/spiffe/helper/cli/Config.java
@@ -62,6 +62,7 @@ class Config {
         val trustStorePath = getProperty(properties, "trustStorePath");
         val trustStorePass = getProperty(properties, "trustStorePass");
 
+        val includeRootCaCertProp = properties.getProperty("includeRootCaCertInChain", "false");
         val keyAlias = properties.getProperty("keyAlias", null);
         val spiffeSocketPath = properties.getProperty("spiffeSocketPath", null);
         val keyStoreTypeProp = properties.getProperty("keyStoreType", null);
@@ -73,6 +74,8 @@ class Config {
             keyStoreType = KeyStoreType.getDefaultType();
         }
 
+        val includeRootCaCert = Boolean.parseBoolean(includeRootCaCertProp);
+
         return KeyStoreOptions.builder()
                 .keyStorePath(Paths.get(keyStorePath))
                 .keyStorePass(keyStorePass)
@@ -80,6 +83,7 @@ class Config {
                 .trustStorePath(Paths.get(trustStorePath))
                 .trustStorePass(trustStorePass)
                 .keyAlias(keyAlias)
+                .includeRootCaCertInChain(includeRootCaCert)
                 .spiffeSocketPath(spiffeSocketPath)
                 .keyStoreType(keyStoreType)
                 .build();

--- a/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/KeyStoreHelperTest.java
+++ b/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/KeyStoreHelperTest.java
@@ -154,39 +154,6 @@ class KeyStoreHelperTest {
         }
     }
 
-    @Test
-    void testCreateHelper_keyStore_cannotStoreCerts() throws SocketEndpointAddressException {
-
-        keyStoreFilePath = Paths.get("dummy://invalid");
-        trustStoreFilePath = Paths.get("dummy://otherinvalid");
-
-        val trustStorePass = "truststore123";
-        val keyStorePass = "keystore123";
-        val keyPass = "keypass123";
-        val alias = "other_alias";
-
-        final KeyStoreHelper.KeyStoreOptions options = KeyStoreHelper.KeyStoreOptions
-                .builder()
-                .keyStorePath(keyStoreFilePath)
-                .keyStorePass(keyStorePass)
-                .trustStorePath(trustStoreFilePath)
-                .trustStorePass(trustStorePass)
-                .keyPass(keyPass)
-                .keyAlias(alias)
-                .workloadApiClient(workloadApiClient)
-                .build();
-
-        try {
-            KeyStoreHelper helper = KeyStoreHelper.create(options);
-            helper.run(false);
-            fail();
-        } catch (KeyStoreHelperException e) {
-            assertEquals("Error running KeyStoreHelper", e.getMessage());
-            assertEquals("java.nio.file.NoSuchFileException: dummy:/invalid", e.getCause().getCause().getMessage());
-        } catch (KeyStoreException e) {
-            fail(e);
-        }
-    }
 
     @Test
     void testCreateKeyStoreHelper_createNewClient() throws Exception {

--- a/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/KeyStoreHelperTest.java
+++ b/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/KeyStoreHelperTest.java
@@ -154,6 +154,39 @@ class KeyStoreHelperTest {
         }
     }
 
+    @Test
+    void testCreateHelper_keyStore_cannotStoreCerts() throws SocketEndpointAddressException {
+
+        keyStoreFilePath = Paths.get("dummy://invalid");
+        trustStoreFilePath = Paths.get("dummy://otherinvalid");
+
+        val trustStorePass = "truststore123";
+        val keyStorePass = "keystore123";
+        val keyPass = "keypass123";
+        val alias = "other_alias";
+
+        final KeyStoreHelper.KeyStoreOptions options = KeyStoreHelper.KeyStoreOptions
+                .builder()
+                .keyStorePath(keyStoreFilePath)
+                .keyStorePass(keyStorePass)
+                .trustStorePath(trustStoreFilePath)
+                .trustStorePass(trustStorePass)
+                .keyPass(keyPass)
+                .keyAlias(alias)
+                .workloadApiClient(workloadApiClient)
+                .build();
+
+        try {
+            KeyStoreHelper helper = KeyStoreHelper.create(options);
+            helper.run(false);
+            fail();
+        } catch (KeyStoreHelperException e) {
+            assertEquals("Error running KeyStoreHelper", e.getMessage());
+            assertEquals("java.nio.file.NoSuchFileException: dummy:/invalid", e.getCause().getCause().getMessage());
+        } catch (KeyStoreException e) {
+            fail(e);
+        }
+    }
 
     @Test
     void testCreateKeyStoreHelper_createNewClient() throws Exception {

--- a/java-spiffe-helper/src/test/resources/testdata/cli/correct-2.conf
+++ b/java-spiffe-helper/src/test/resources/testdata/cli/correct-2.conf
@@ -1,0 +1,9 @@
+keyStorePath = keystore123.p12
+keyStorePass = example123
+keyPass = pass123
+includeRootCaCertInChain = true
+trustStorePath = truststore123.p12
+trustStorePass = otherpass123
+keyStoreType = jks
+keyAlias = other_alias
+spiffeSocketPath = unix:/tmp/test


### PR DESCRIPTION
This PR adds a new configuration property `includeRootCaCertInChain` to the java-spiffe-helper to include a self-signed certificate in the chain that is stored in the Java KeyStore. 

The motivation is the following use case: importing SVIDs to an Oracle Wallet using the `orapki` tool from a Java KeyStore and TrustStore. 
Some versions of the `orapki` require that a self-signed certificate be present in the certificate chain to import it in the Oracle Wallet. 
Setting the new property `includeRootCaCertInChain` to `true`, the `java-spiffe-helper` adds a not-expired self-signed certificate to the certificate chain that is stored in the KeyStore. 