### PR TITLE
Solve memory leak. 

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/DefaultWorkloadApiClient.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/DefaultWorkloadApiClient.java
@@ -334,12 +334,13 @@ public final class DefaultWorkloadApiClient implements WorkloadApiClient {
                 for (val context : cancellableContexts) {
                     context.close();
                 }
-                retryExecutor.shutdown();
-                executorService.shutdown();
 
                 if (managedChannel != null) {
                     managedChannel.close();
                 }
+
+                retryExecutor.shutdown();
+                executorService.shutdown();
                 closed = true;
             }
         }

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/StreamObservers.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/StreamObservers.java
@@ -21,7 +21,6 @@ final class StreamObservers {
 
     private static final String INVALID_ARGUMENT = "INVALID_ARGUMENT";
     private static final String STREAM_IS_COMPLETED = "Workload API stream is completed";
-    public static final String CANCELLED = "CANCELLED";
 
     private StreamObservers() {
     }
@@ -46,7 +45,7 @@ final class StreamObservers {
 
             @Override
             public void onError(final Throwable t) {
-                if (!t.getMessage().contains(CANCELLED)) {
+                if (Status.fromThrowable(t).getCode() != Status.Code.CANCELLED) {
                     log.log(Level.SEVERE, "X.509 context observer error", t);
                 }
                 handleWatchX509ContextError(t);
@@ -100,7 +99,7 @@ final class StreamObservers {
 
             @Override
             public void onError(final Throwable t) {
-                if (!t.getMessage().contains(CANCELLED)) {
+                if (Status.fromThrowable(t).getCode() != Status.Code.CANCELLED) {
                     log.log(Level.SEVERE, "X.509 bundles observer error", t);
                 }
                 handleWatchX509BundlesError(t);
@@ -154,7 +153,7 @@ final class StreamObservers {
 
             @Override
             public void onError(final Throwable t) {
-                if (!t.getMessage().contains(CANCELLED)) {
+                if (Status.fromThrowable(t).getCode() != Status.Code.CANCELLED) {
                     log.log(Level.SEVERE, "JWT observer error", t);
                 }
                 handleWatchJwtBundleError(t);

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/StreamObservers.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/StreamObservers.java
@@ -21,6 +21,7 @@ final class StreamObservers {
 
     private static final String INVALID_ARGUMENT = "INVALID_ARGUMENT";
     private static final String STREAM_IS_COMPLETED = "Workload API stream is completed";
+    public static final String CANCELLED = "CANCELLED";
 
     private StreamObservers() {
     }
@@ -45,7 +46,9 @@ final class StreamObservers {
 
             @Override
             public void onError(final Throwable t) {
-                log.log(Level.SEVERE, "X.509 context observer error", t);
+                if (!t.getMessage().contains(CANCELLED)) {
+                    log.log(Level.SEVERE, "X.509 context observer error", t);
+                }
                 handleWatchX509ContextError(t);
             }
 
@@ -59,7 +62,7 @@ final class StreamObservers {
 
             private void handleX509ContextRetry(Throwable t) {
                 if (retryHandler.shouldRetry()) {
-                    log.log(Level.INFO, "Retrying connecting to Workload API to register X.509 context watcher");
+                    log.log(Level.FINE, "Retrying connecting to Workload API to register X.509 context watcher");
                     retryHandler.scheduleRetry(() ->
                             cancellableContext.run(
                                     () -> workloadApiAsyncStub.fetchX509SVID(newX509SvidRequest(),
@@ -97,7 +100,9 @@ final class StreamObservers {
 
             @Override
             public void onError(final Throwable t) {
-                log.log(Level.SEVERE, "X.509 bundles observer error", t);
+                if (!t.getMessage().contains(CANCELLED)) {
+                    log.log(Level.SEVERE, "X.509 bundles observer error", t);
+                }
                 handleWatchX509BundlesError(t);
             }
 
@@ -111,7 +116,7 @@ final class StreamObservers {
 
             private void handleX509BundlesRetry(Throwable t) {
                 if (retryHandler.shouldRetry()) {
-                    log.log(Level.INFO, "Retrying connecting to Workload API to register X.509 bundles watcher");
+                    log.log(Level.FINE, "Retrying connecting to Workload API to register X.509 bundles watcher");
                     retryHandler.scheduleRetry(() ->
                             cancellableContext.run(
                                     () -> workloadApiAsyncStub.fetchX509Bundles(newX509BundlesRequest(),
@@ -149,7 +154,9 @@ final class StreamObservers {
 
             @Override
             public void onError(final Throwable t) {
-                log.log(Level.SEVERE, "JWT observer error", t);
+                if (!t.getMessage().contains(CANCELLED)) {
+                    log.log(Level.SEVERE, "JWT observer error", t);
+                }
                 handleWatchJwtBundleError(t);
             }
 
@@ -163,7 +170,7 @@ final class StreamObservers {
 
             private void handleJwtBundleRetry(Throwable t) {
                 if (retryHandler.shouldRetry()) {
-                    log.log(Level.INFO, "Retrying connecting to Workload API to register JWT Bundles watcher");
+                    log.log(Level.FINE, "Retrying connecting to Workload API to register JWT Bundles watcher");
                     retryHandler.scheduleRetry(() ->
                             cancellableContext.run(() -> workloadApiAsyncStub.fetchJWTBundles(newJwtBundlesRequest(),
                                     this)));

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/retry/RetryHandler.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/retry/RetryHandler.java
@@ -28,6 +28,10 @@ public class RetryHandler {
      * @param runnable the task to be scheduled for execution
      */
     public void scheduleRetry(final Runnable runnable) {
+        if (executor.isShutdown()) {
+            return;
+        }
+
         if (exponentialBackoffPolicy.reachedMaxRetries(retryCount)) {
             return;
         }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/retry/RetryHandlerTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/retry/RetryHandlerTest.java
@@ -11,8 +11,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.*;
 
 class RetryHandlerTest {
 
@@ -78,7 +77,8 @@ class RetryHandlerTest {
 
         // fourth retry exceeds max retries
         retryHandler.scheduleRetry(runnable);
-        verifyNoInteractions(scheduledExecutorService);
+        verify(scheduledExecutorService).isShutdown();
+        verifyNoMoreInteractions(scheduledExecutorService);
     }
 
     @Test


### PR DESCRIPTION
This recent [PR](https://github.com/spiffe/java-spiffe/pull/102) introduced a memory leak; the exact reason is unknown, but it seems that the order in which the underlying components of the WorkloadApiClient are liberated is critical.

This PR reverts those changes, solving #111, and also solves the error that the previous PR was trying to solve: #100 

 