### PR TITLE
Add SVID hints on workload api client

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
@@ -221,7 +221,7 @@ public class JwtSvid {
      *
      * @return the SVID hint
      */
-    public String gethint() {
+    public String getHint() {
         return hint;
     }
 

--- a/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
@@ -69,6 +69,12 @@ public class JwtSvid {
      */
     Date issuedAt;
 
+    /**
+     * Hint is an operator-specified string used to provide guidance on how this
+     * identity should be used by a workload when more than one SVID is returned.
+     */
+    String hint;
+
     public static final String HEADER_TYP_JWT = "JWT";
     public static final String HEADER_TYP_JOSE = "JOSE";
 
@@ -77,13 +83,16 @@ public class JwtSvid {
                     final Date issuedAt,
                     final Date expiry,
                     final Map<String, Object> claims,
-                    final String token) {
+                    final String token,
+                    final String hint
+                    ) {
         this.spiffeId = spiffeId;
         this.audience = audience;
         this.expiry = expiry;
         this.claims = claims;
         this.token = token;
         this.issuedAt = issuedAt;
+        this.hint = hint;
     }
 
     /**
@@ -112,7 +121,9 @@ public class JwtSvid {
      */
     public static JwtSvid parseAndValidate(@NonNull final String token,
                                            @NonNull final BundleSource<JwtBundle> jwtBundleSource,
-                                           @NonNull final Set<String> audience)
+                                           @NonNull final Set<String> audience,
+                                           @NonNull final String hint
+    )
             throws JwtSvidException, BundleNotFoundException, AuthorityNotFoundException {
 
         if (StringUtils.isBlank(token)) {
@@ -142,7 +153,7 @@ public class JwtSvid {
 
         val claimAudience = new HashSet<>(claimsSet.getAudience());
 
-        return new JwtSvid(spiffeId, claimAudience, issuedAt, expirationTime, claimsSet.getClaims(), token);
+        return new JwtSvid(spiffeId, claimAudience, issuedAt, expirationTime, claimsSet.getClaims(), token, hint);
     }
 
     /**
@@ -160,7 +171,7 @@ public class JwtSvid {
      *                                  when the header 'typ' is present and is not 'JWT' or 'JOSE'.
      * @throws IllegalArgumentException when the token cannot be parsed
      */
-    public static JwtSvid parseInsecure(@NonNull final String token, @NonNull final Set<String> audience) throws JwtSvidException {
+    public static JwtSvid parseInsecure(@NonNull final String token, @NonNull final Set<String> audience, @NonNull final String hint) throws JwtSvidException {
         if (StringUtils.isBlank(token)) {
             throw new IllegalArgumentException("Token cannot be blank");
         }
@@ -182,7 +193,7 @@ public class JwtSvid {
 
         val claimAudience = new HashSet<>(claimsSet.getAudience());
 
-        return new JwtSvid(spiffeId, claimAudience, issuedAt, expirationTime, claimsSet.getClaims(), token);
+        return new JwtSvid(spiffeId, claimAudience, issuedAt, expirationTime, claimsSet.getClaims(), token, hint);
     }
 
     /**
@@ -204,6 +215,16 @@ public class JwtSvid {
         // defensive copy to prevent exposing a mutable object
         return new Date(expiry.getTime());
     }
+
+    /**
+     * Returns the SVID hint.
+     *
+     * @return the SVID hint
+     */
+    public String gethint() {
+        return hint;
+    }
+
 
     /**
      * Returns the map of claims.

--- a/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
@@ -122,7 +122,7 @@ public class JwtSvid {
     public static JwtSvid parseAndValidate(@NonNull final String token,
                                            @NonNull final BundleSource<JwtBundle> jwtBundleSource,
                                            @NonNull final Set<String> audience,
-                                           @NonNull final String hint
+                                           final String hint
     )
             throws JwtSvidException, BundleNotFoundException, AuthorityNotFoundException {
 
@@ -171,7 +171,7 @@ public class JwtSvid {
      *                                  when the header 'typ' is present and is not 'JWT' or 'JOSE'.
      * @throws IllegalArgumentException when the token cannot be parsed
      */
-    public static JwtSvid parseInsecure(@NonNull final String token, @NonNull final Set<String> audience, @NonNull final String hint) throws JwtSvidException {
+    public static JwtSvid parseInsecure(@NonNull final String token, @NonNull final Set<String> audience, final String hint) throws JwtSvidException {
         if (StringUtils.isBlank(token)) {
             throw new IllegalArgumentException("Token cannot be blank");
         }

--- a/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
@@ -85,7 +85,7 @@ public class JwtSvid {
                     final Map<String, Object> claims,
                     final String token,
                     final String hint
-                    ) {
+    ) {
         this.spiffeId = spiffeId;
         this.audience = audience;
         this.expiry = expiry;
@@ -104,6 +104,39 @@ public class JwtSvid {
      * @param jwtBundleSource an implementation of a {@link BundleSource} that provides the JWT authorities to
      *                        verify the signature
      * @param audience        audience as a list of strings used to validate the 'aud' claim
+     * @return an instance of a {@link JwtSvid} with a SPIFFE ID parsed from the 'sub', audience from 'aud', and expiry
+     * from 'exp' claim.
+     * @throws JwtSvidException           when the token expired or the expiration claim is missing,
+     *                                    when the algorithm is not supported (See {@link JwtSignatureAlgorithm}),
+     *                                    when the header 'kid' is missing,
+     *                                    when the header 'typ' is present and is not 'JWT' or 'JOSE'
+     *                                    when the signature cannot be verified,
+     *                                    when the 'aud' claim has an audience that is not in the audience list
+     *                                    provided as parameter
+     * @throws IllegalArgumentException   when the token is blank or cannot be parsed
+     * @throws BundleNotFoundException    if the bundle for the trust domain of the spiffe id from the 'sub'
+     *                                    cannot be found in the JwtBundleSource
+     * @throws AuthorityNotFoundException if the authority cannot be found in the bundle using the value from
+     *                                    the 'kid' header
+     */
+    public static JwtSvid parseAndValidate(@NonNull final String token,
+                                           @NonNull final BundleSource<JwtBundle> jwtBundleSource,
+                                           @NonNull final Set<String> audience)
+            throws JwtSvidException, BundleNotFoundException, AuthorityNotFoundException {
+
+        return parseAndValidate(token, jwtBundleSource, audience, null);
+    }
+
+    /**
+     * Parses and validates a JWT-SVID token and returns an instance of {@link JwtSvid}.
+     * <p>
+     * The JWT-SVID signature is verified using the JWT bundle source.
+     *
+     * @param token           a token as a string that is parsed and validated
+     * @param jwtBundleSource an implementation of a {@link BundleSource} that provides the JWT authorities to
+     *                        verify the signature
+     * @param audience        audience as a list of strings used to validate the 'aud' claim
+     * @param hint            a hint that can be used to provide guidance on how this identity should be used
      * @return an instance of a {@link JwtSvid} with a SPIFFE ID parsed from the 'sub', audience from 'aud', and expiry
      * from 'exp' claim.
      * @throws JwtSvidException           when the token expired or the expiration claim is missing,
@@ -163,6 +196,26 @@ public class JwtSvid {
      *
      * @param token    a token as a string that is parsed and validated
      * @param audience audience as a list of strings used to validate the 'aud' claim
+     * @return an instance of a {@link JwtSvid} with a SPIFFE ID parsed from the 'sub', audience from 'aud', and expiry
+     * from 'exp' claim.
+     * @throws JwtSvidException         when the token expired or the expiration claim is missing,
+     *                                  when the 'aud' has an audience that is not in the audience provided as parameter,
+     *                                  when the 'alg' is not supported (See {@link JwtSignatureAlgorithm}),
+     *                                  when the header 'typ' is present and is not 'JWT' or 'JOSE'.
+     * @throws IllegalArgumentException when the token cannot be parsed
+     */
+    public static JwtSvid parseInsecure(@NonNull final String token, @NonNull final Set<String> audience) throws JwtSvidException {
+        return parseInsecure(token, audience, null);
+    }
+
+    /**
+     * Parses and validates a JWT-SVID token and returns an instance of a {@link JwtSvid}.
+     * <p>
+     * The JWT-SVID signature is not verified.
+     *
+     * @param token    a token as a string that is parsed and validated
+     * @param audience audience as a list of strings used to validate the 'aud'
+     * @param hint     a hint that can be used to provide guidance on how this identity should be used
      * @return an instance of a {@link JwtSvid} with a SPIFFE ID parsed from the 'sub', audience from 'aud', and expiry
      * from 'exp' claim.
      * @throws JwtSvidException         when the token expired or the expiration claim is missing,

--- a/java-spiffe-core/src/main/java/io/spiffe/svid/x509svid/X509Svid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/x509svid/X509Svid.java
@@ -115,7 +115,7 @@ public class X509Svid {
         } catch (IOException e) {
             throw new X509SvidException("Cannot read private key file", e);
         }
-        return createX509Svid(certsBytes, privateKeyBytes, KeyFileFormat.PEM, EMPTY);
+        return createX509Svid(certsBytes, privateKeyBytes, KeyFileFormat.PEM, null);
     }
 
     /**
@@ -126,6 +126,23 @@ public class X509Svid {
      *
      * @param certsBytes      chain of certificates as a byte array
      * @param privateKeyBytes private key as byte array
+     * @return a {@link X509Svid} parsed from the given certBytes and privateKeyBytes
+     * @throws X509SvidException if the given certsBytes or privateKeyBytes cannot be parsed
+     */
+    public static X509Svid parse(@NonNull final byte[] certsBytes, @NonNull final byte[] privateKeyBytes)
+            throws X509SvidException {
+        return parse(certsBytes, privateKeyBytes, null);
+    }
+
+    /**
+     * Parses the X.509 SVID from PEM or DER blocks containing certificate chain and key
+     * bytes. The key must be a PEM block with PKCS#8.
+     * <p>
+     * It is assumed that the leaf certificate is always the first certificate in the parsed chain.
+     *
+     * @param certsBytes      chain of certificates as a byte array
+     * @param privateKeyBytes private key as byte array
+     * @param hint            a hint that can be used to provide guidance on how this identity should be used
      * @return a {@link X509Svid} parsed from the given certBytes and privateKeyBytes
      * @throws X509SvidException if the given certsBytes or privateKeyBytes cannot be parsed
      */
@@ -142,6 +159,23 @@ public class X509Svid {
      *
      * @param certsBytes      chain of certificates as a byte array
      * @param privateKeyBytes private key as byte array
+     * @return a {@link X509Svid} parsed from the given certBytes and privateKeyBytes
+     * @throws X509SvidException if the given certsBytes or privateKeyBytes cannot be parsed
+     */
+    public static X509Svid parseRaw(@NonNull final byte[] certsBytes,
+                                    @NonNull final byte[] privateKeyBytes) throws X509SvidException {
+        return parseRaw(certsBytes, privateKeyBytes, null);
+    }
+
+    /**
+     * Parses the X509-SVID from certificate and key bytes. The certificate must be ASN.1 DER (concatenated with
+     * no intermediate padding if there are more than one certificate). The key must be a PKCS#8 ASN.1 DER.
+     * <p>
+     * It is assumed that the leaf certificate is always the first certificate in the parsed chain.
+     *
+     * @param certsBytes      chain of certificates as a byte array
+     * @param privateKeyBytes private key as byte array
+     * @param hint            a hint that can be used to provide guidance on how this identity should be used
      * @return a {@link X509Svid} parsed from the given certBytes and privateKeyBytes
      * @throws X509SvidException if the given certsBytes or privateKeyBytes cannot be parsed
      */

--- a/java-spiffe-core/src/main/java/io/spiffe/svid/x509svid/X509Svid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/x509svid/X509Svid.java
@@ -22,6 +22,8 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
 /**
  * Represents a SPIFFE X.509 SVID.
  * <p>
@@ -113,7 +115,7 @@ public class X509Svid {
         } catch (IOException e) {
             throw new X509SvidException("Cannot read private key file", e);
         }
-        return createX509Svid(certsBytes, privateKeyBytes, KeyFileFormat.PEM, "");
+        return createX509Svid(certsBytes, privateKeyBytes, KeyFileFormat.PEM, EMPTY);
     }
 
     /**
@@ -127,7 +129,7 @@ public class X509Svid {
      * @return a {@link X509Svid} parsed from the given certBytes and privateKeyBytes
      * @throws X509SvidException if the given certsBytes or privateKeyBytes cannot be parsed
      */
-    public static X509Svid parse(@NonNull final byte[] certsBytes, @NonNull final byte[] privateKeyBytes, @NonNull final String hint)
+    public static X509Svid parse(@NonNull final byte[] certsBytes, @NonNull final byte[] privateKeyBytes, final String hint)
             throws X509SvidException {
         return createX509Svid(certsBytes, privateKeyBytes, KeyFileFormat.PEM, hint);
     }
@@ -145,7 +147,7 @@ public class X509Svid {
      */
     public static X509Svid parseRaw(@NonNull final byte[] certsBytes,
                                     @NonNull final byte[] privateKeyBytes,
-                                    @NonNull final String hint) throws X509SvidException {
+                                    final String hint) throws X509SvidException {
         return createX509Svid(certsBytes, privateKeyBytes, KeyFileFormat.DER, hint);
     }
 

--- a/java-spiffe-core/src/main/java/io/spiffe/svid/x509svid/X509Svid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/x509svid/X509Svid.java
@@ -22,8 +22,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-
 /**
  * Represents a SPIFFE X.509 SVID.
  * <p>

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/DefaultWorkloadApiClient.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/DefaultWorkloadApiClient.java
@@ -41,6 +41,7 @@ import java.util.logging.Level;
 import static io.spiffe.workloadapi.StreamObservers.getJwtBundleStreamObserver;
 import static io.spiffe.workloadapi.StreamObservers.getX509BundlesStreamObserver;
 import static io.spiffe.workloadapi.StreamObservers.getX509ContextStreamObserver;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 /**
  * Represents a client to interact with the Workload API.
@@ -306,7 +307,7 @@ public final class DefaultWorkloadApiClient implements WorkloadApiClient {
         if (response == null || StringUtils.isBlank(response.getSpiffeId())) {
             throw new JwtSvidException("Error validating JWT SVID. Empty response from Workload API");
         }
-        return JwtSvid.parseInsecure(token, Collections.singleton(audience), "");
+        return JwtSvid.parseInsecure(token, Collections.singleton(audience), EMPTY);
     }
 
     /**

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/GrpcConversionUtils.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/GrpcConversionUtils.java
@@ -15,11 +15,7 @@ import io.spiffe.svid.x509svid.X509Svid;
 import io.spiffe.workloadapi.grpc.Workload;
 import lombok.val;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Utility methods for converting GRPC objects to JAVA-SPIFFE domain objects.
@@ -132,9 +128,16 @@ final class GrpcConversionUtils {
     private static List<X509Svid> getListOfX509Svid(final Workload.X509SVIDResponse x509SvidResponse) throws X509ContextException{
 
         final List<X509Svid> result = new ArrayList<>();
+        HashSet<String> hints = new HashSet<>();
 
         for (Workload.X509SVID x509SVID : x509SvidResponse.getSvidsList()) {
+            // In the event of more than one X509SVID message with the same hint value set, then the first message in the
+            // list SHOULD be selected.
+            if (hints.contains(x509SVID.getHint())) {
+                continue;
+            }
             val svid = createAndValidateX509Svid(x509SVID);
+            hints.add(svid.getHint());
             result.add(svid);
         }
         return result;
@@ -144,9 +147,9 @@ final class GrpcConversionUtils {
         byte[] certsBytes = x509SVID.getX509Svid().toByteArray();
         byte[] privateKeyBytes = x509SVID.getX509SvidKey().toByteArray();
 
-        X509Svid svid = null;
+        X509Svid svid;
         try {
-            svid = X509Svid.parseRaw(certsBytes, privateKeyBytes);
+            svid = X509Svid.parseRaw(certsBytes, privateKeyBytes, x509SVID.getHint());
         } catch (X509SvidException e) {
             throw new X509ContextException("X.509 SVID response could not be processed", e);
         }

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/GrpcConversionUtils.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/GrpcConversionUtils.java
@@ -15,7 +15,12 @@ import io.spiffe.svid.x509svid.X509Svid;
 import io.spiffe.workloadapi.grpc.Workload;
 import lombok.val;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 
 /**
  * Utility methods for converting GRPC objects to JAVA-SPIFFE domain objects.

--- a/java-spiffe-core/src/main/proto/workload.proto
+++ b/java-spiffe-core/src/main/proto/workload.proto
@@ -76,6 +76,12 @@ message X509SVID {
 
     // Required. ASN.1 DER encoded X.509 bundle for the trust domain.
     bytes bundle = 4;
+
+    // Optional. An operator-specified string used to provide guidance on how this
+    // identity should be used by a workload when more than one SVID is returned.
+    // For example, `internal` and `external` to indicate an SVID for internal or
+    // external use, respectively.
+    string hint = 5;
 }
 
 // The X509BundlesRequest message conveys parameters for requesting X.509
@@ -117,6 +123,12 @@ message JWTSVID {
 
     // Required. Encoded JWT using JWS Compact Serialization.
     string svid = 2;
+
+    // Optional. An operator-specified string used to provide guidance on how this
+    // identity should be used by a workload when more than one SVID is returned.
+    // For example, `internal` and `external` to indicate an SVID for internal or
+    // external use, respectively.
+    string hint = 3;
 }
 
 // The JWTBundlesRequest message conveys parameters for requesting JWT bundles.

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
@@ -57,7 +57,7 @@ class JwtSvidParseAndValidateTest {
     void parseAndValidateInvalidJwt(TestCase testCase) {
         try {
             String token = testCase.generateToken.get();
-            JwtSvid.parseAndValidate(token, testCase.jwtBundle, testCase.audience, "");
+            JwtSvid.parseAndValidate(token, testCase.jwtBundle, testCase.audience);
             fail("expected error: " + testCase.expectedException.getMessage());
         } catch (Exception e) {
             assertEquals(testCase.expectedException.getClass(), e.getClass());
@@ -72,7 +72,7 @@ class JwtSvidParseAndValidateTest {
         Set<String> audience = Collections.singleton("audience");
 
         try {
-            JwtSvid.parseAndValidate(null, jwtBundle, audience, "");
+            JwtSvid.parseAndValidate(null, jwtBundle, audience);
         } catch (NullPointerException e) {
             assertEquals("token is marked non-null but is null", e.getMessage());
         }
@@ -85,7 +85,7 @@ class JwtSvidParseAndValidateTest {
         Set<String> audience = Collections.singleton("audience");
 
         try {
-            JwtSvid.parseAndValidate("", jwtBundle, audience, "");
+            JwtSvid.parseAndValidate("", jwtBundle, audience);
         } catch (IllegalArgumentException e) {
             assertEquals("Token cannot be blank", e.getMessage());
         }
@@ -95,7 +95,7 @@ class JwtSvidParseAndValidateTest {
     void testParseAndValidate_nullBundle_throwsNullPointerException() throws JwtSvidException, AuthorityNotFoundException, BundleNotFoundException {
         Set<String> audience = Collections.singleton("audience");
         try {
-            JwtSvid.parseAndValidate("token", null, audience, "");
+            JwtSvid.parseAndValidate("token", null, audience);
         } catch (NullPointerException e) {
             assertEquals("jwtBundleSource is marked non-null but is null", e.getMessage());
         }
@@ -107,7 +107,7 @@ class JwtSvidParseAndValidateTest {
         JwtBundle jwtBundle = new JwtBundle(trustDomain);
 
         try {
-            JwtSvid.parseAndValidate("token", jwtBundle, null, "");
+            JwtSvid.parseAndValidate("token", jwtBundle, null);
         } catch (NullPointerException e) {
             assertEquals("audience is marked non-null but is null", e.getMessage());
         }

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
@@ -113,19 +113,6 @@ class JwtSvidParseAndValidateTest {
         }
     }
 
-    @Test
-    void testParseAndValidate_nullHint_throwsNullPointerException() throws JwtSvidException, AuthorityNotFoundException, BundleNotFoundException {
-        TrustDomain trustDomain = TrustDomain.parse("test.domain");
-        JwtBundle jwtBundle = new JwtBundle(trustDomain);
-        Set<String> audience = Collections.singleton("audience");
-
-        try {
-            JwtSvid.parseAndValidate("token", jwtBundle, audience, null);
-        } catch (NullPointerException e) {
-            assertEquals("hint is marked non-null but is null", e.getMessage());
-        }
-    }
-
     static Stream<Arguments> provideSuccessScenarios() {
         KeyPair key1 = TestUtils.generateECKeyPair(Curve.P_521);
         KeyPair key2 = TestUtils.generateECKeyPair(Curve.P_521);

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
@@ -43,7 +43,7 @@ class JwtSvidParseAndValidateTest {
 
             assertEquals(testCase.expectedJwtSvid.getSpiffeId(), jwtSvid.getSpiffeId());
             assertEquals(testCase.expectedJwtSvid.getAudience(), jwtSvid.getAudience());
-            assertEquals(testCase.expectedJwtSvid.gethint(), jwtSvid.gethint());
+            assertEquals(testCase.expectedJwtSvid.getHint(), jwtSvid.getHint());
             assertEquals(testCase.expectedJwtSvid.getExpiry().toInstant().getEpochSecond(), jwtSvid.getExpiry().toInstant().getEpochSecond());
             assertEquals(token, jwtSvid.getToken());
             assertEquals(token, jwtSvid.marshal());

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
@@ -102,17 +102,6 @@ class JwtSvidParseInsecureTest {
         }
     }
 
-    @Test
-    void testParseInsecure_nullHint_throwsNullPointerException() throws JwtSvidException {
-        Set<String> audience = Collections.singleton("audience");
-
-        try {
-            JwtSvid.parseInsecure("", audience, null);
-        } catch (NullPointerException e) {
-            assertEquals("hint is marked non-null but is null", e.getMessage());
-        }
-    }
-
     static Stream<Arguments> provideSuccessScenarios() {
         KeyPair key1 = TestUtils.generateECKeyPair(Curve.P_521);
         KeyPair key2 = TestUtils.generateECKeyPair(Curve.P_521);

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
@@ -42,7 +42,7 @@ class JwtSvidParseInsecureTest {
 
             assertEquals(testCase.expectedJwtSvid.getSpiffeId(), jwtSvid.getSpiffeId());
             assertEquals(testCase.expectedJwtSvid.getAudience(), jwtSvid.getAudience());
-            assertEquals(testCase.expectedJwtSvid.gethint(), jwtSvid.gethint());
+            assertEquals(testCase.expectedJwtSvid.getHint(), jwtSvid.getHint());
             assertEquals(testCase.expectedJwtSvid.getExpiry().toInstant().getEpochSecond(), jwtSvid.getExpiry().toInstant().getEpochSecond());
             assertEquals(token, jwtSvid.getToken());
         } catch (Exception e) {

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
@@ -55,7 +55,7 @@ class JwtSvidParseInsecureTest {
     void parseInvalidJwt(TestCase testCase) {
         try {
             String token = testCase.generateToken.get();
-            JwtSvid.parseInsecure(token, testCase.audience, "");
+            JwtSvid.parseInsecure(token, testCase.audience);
             fail("expected error: " + testCase.expectedException.getMessage());
         } catch (Exception e) {
             assertEquals(testCase.expectedException.getClass(), e.getClass());
@@ -69,7 +69,7 @@ class JwtSvidParseInsecureTest {
         Set<String> audience = Collections.singleton("audience");
 
         try {
-            JwtSvid.parseInsecure(null, audience, "");
+            JwtSvid.parseInsecure(null, audience);
         } catch (NullPointerException e) {
             assertEquals("token is marked non-null but is null", e.getMessage());
         }
@@ -79,7 +79,7 @@ class JwtSvidParseInsecureTest {
     void testParseAndValidate_emptyToken_throwsIllegalArgumentException() throws JwtSvidException {
         Set<String> audience = Collections.singleton("audience");
         try {
-            JwtSvid.parseInsecure("", audience, "");
+            JwtSvid.parseInsecure("", audience);
         } catch (IllegalArgumentException e) {
             assertEquals("Token cannot be blank", e.getMessage());
         }
@@ -95,7 +95,7 @@ class JwtSvidParseInsecureTest {
             Date expiration = new Date(System.currentTimeMillis() + 3600000);
             JWTClaimsSet claims = TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), expiration);
 
-            JwtSvid.parseInsecure(TestUtils.generateToken(claims, key1, "authority1"), null, "");
+            JwtSvid.parseInsecure(TestUtils.generateToken(claims, key1, "authority1"), null);
 
         } catch (NullPointerException e) {
             assertEquals("audience is marked non-null but is null", e.getMessage());

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidTest.java
@@ -48,9 +48,11 @@ class X509SvidTest {
                         .name("1. Single certificate and key")
                         .certsPath(certSingle)
                         .keyPath(keyRSA)
+                        .hint("")
                         .expectedSpiffeId(SpiffeId.fromSegments(TrustDomain.parse("example.org"), "workload-1"))
                         .expectedNumberOfCerts(1)
                         .expectedPrivateKeyAlgorithm("RSA")
+                        .expectedHint("")
                         .build()
                 ),
                 Arguments.of(TestCase
@@ -58,9 +60,11 @@ class X509SvidTest {
                         .name("2. Certificate with intermediate and key")
                         .certsPath(certMultiple)
                         .keyPath(keyECDSA)
+                        .hint("")
                         .expectedSpiffeId(SpiffeId.fromSegments(TrustDomain.parse("example.org"), "workload-1"))
                         .expectedNumberOfCerts(2)
                         .expectedPrivateKeyAlgorithm("EC")
+                        .expectedHint("")
                         .build()
                 ),
                 Arguments.of(TestCase
@@ -68,7 +72,9 @@ class X509SvidTest {
                         .name("3. Missing certificate")
                         .certsPath(keyRSA)
                         .keyPath(keyRSA)
+                        .hint("")
                         .expectedError("Certificate could not be parsed from cert bytes")
+                        .expectedHint("")
                         .build()
                 ),
                 Arguments.of(TestCase
@@ -76,6 +82,7 @@ class X509SvidTest {
                         .name("4. Missing key")
                         .certsPath(certSingle)
                         .keyPath(certSingle)
+                        .hint("")
                         .expectedError("Private Key could not be parsed from key bytes")
                         .build()
                 ),
@@ -84,6 +91,7 @@ class X509SvidTest {
                         .name("5. Corrupted private key")
                         .certsPath(certSingle)
                         .keyPath(corrupted)
+                        .hint("")
                         .expectedError("Private Key could not be parsed from key bytes")
                         .build()
                 ),
@@ -92,6 +100,7 @@ class X509SvidTest {
                         .name("6. Corrupted certificate")
                         .certsPath(corrupted)
                         .keyPath(keyRSA)
+                        .hint("")
                         .expectedError("Certificate could not be parsed from cert bytes")
                         .build()
                 ),
@@ -100,6 +109,7 @@ class X509SvidTest {
                         .name("7. Certificate without SPIFFE ID")
                         .certsPath(leafEmptyID)
                         .keyPath(keyRSA)
+                        .hint("")
                         .expectedError("Certificate does not contain SPIFFE ID in the URI SAN")
                         .build()
                 ),
@@ -108,6 +118,7 @@ class X509SvidTest {
                         .name("8. Leaf certificate with CA flag set to true")
                         .certsPath(leafCAtrue)
                         .keyPath(keyRSA)
+                        .hint("")
                         .expectedError("Leaf certificate must not have CA flag set to true")
                         .build()
                 ),
@@ -116,6 +127,7 @@ class X509SvidTest {
                         .name("9. Leaf certificate without digitalSignature as key usage")
                         .certsPath(leafNoDigitalSignature)
                         .keyPath(keyRSA)
+                        .hint("")
                         .expectedError("Leaf certificate must have 'digitalSignature' as key usage")
                         .build()
                 ),
@@ -124,6 +136,7 @@ class X509SvidTest {
                         .name("10. Leaf certificate with certSign as key usage")
                         .certsPath(leafCertSign)
                         .keyPath(keyRSA)
+                        .hint("")
                         .expectedError("Leaf certificate must not have 'keyCertSign' as key usage")
                         .build()
                 ),
@@ -132,6 +145,7 @@ class X509SvidTest {
                         .name("11. Leaf certificate with cRLSign as key usage")
                         .certsPath(leafCRLSign)
                         .keyPath(keyRSA)
+                        .hint("")
                         .expectedError("Leaf certificate must not have 'cRLSign' as key usage")
                         .build()
                 ),
@@ -140,6 +154,7 @@ class X509SvidTest {
                         .name("12. Signing certificate without CA flag")
                         .certsPath(signNoCA)
                         .keyPath(keyRSA)
+                        .hint("")
                         .expectedError("Signing certificate must have CA flag set to true")
                         .build()
                 ),
@@ -148,7 +163,20 @@ class X509SvidTest {
                         .name("13. Signing certificate without CA flag")
                         .certsPath(signNoKeyCertSign)
                         .keyPath(keyRSA)
+                        .hint("")
                         .expectedError("Signing certificate must have 'keyCertSign' as key usage")
+                        .build()
+                ),
+                Arguments.of(TestCase
+                        .builder()
+                        .name("14. SVID with non-empty hint")
+                        .certsPath(certSingle)
+                        .keyPath(keyRSA)
+                        .hint("internal")
+                        .expectedSpiffeId(SpiffeId.fromSegments(TrustDomain.parse("example.org"), "workload-1"))
+                        .expectedNumberOfCerts(1)
+                        .expectedPrivateKeyAlgorithm("RSA")
+                        .expectedHint("internal")
                         .build()
                 )
         );
@@ -176,8 +204,10 @@ class X509SvidTest {
         byte[] keyBytes = Files.readAllBytes(keyPath);
 
         try {
-            X509Svid x509Svid = X509Svid.parseRaw(certBytes, keyBytes);
+            X509Svid x509Svid = X509Svid.parseRaw(certBytes, keyBytes, "external");
             assertEquals("spiffe://example.org/workload-server", x509Svid.getSpiffeId().toString());
+            assertEquals("external", x509Svid.getHint());
+
         } catch (X509SvidException e) {
             fail(e);
         }
@@ -186,7 +216,7 @@ class X509SvidTest {
     @Test
     void testParseRawNullCertsBytesArgument() {
         try {
-            X509Svid.parseRaw(null, new byte[]{});
+            X509Svid.parseRaw(null, new byte[]{}, "");
             fail();
         } catch (NullPointerException e) {
             assertEquals("certsBytes is marked non-null but is null", e.getMessage());
@@ -198,10 +228,22 @@ class X509SvidTest {
     @Test
     void testParseRawNullPrivateKeyBytesArgument() {
         try {
-            X509Svid.parseRaw(new byte[]{}, null);
+            X509Svid.parseRaw(new byte[]{}, null, "");
             fail();
         } catch (NullPointerException e) {
             assertEquals("privateKeyBytes is marked non-null but is null", e.getMessage());
+        } catch (X509SvidException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void testParseRawNullHintArgument() {
+        try {
+            X509Svid.parseRaw(new byte[]{}, new byte[]{}, null);
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("hint is marked non-null but is null", e.getMessage());
         } catch (X509SvidException e) {
             fail();
         }
@@ -252,7 +294,7 @@ class X509SvidTest {
     @Test
     void testParse_nullByteArray_throwsNullPointerException() throws X509SvidException {
         try {
-            X509Svid.parse(null, "key".getBytes());
+            X509Svid.parse(null, "key".getBytes(), "");
             fail("should have thrown exception");
         } catch (NullPointerException e) {
             assertEquals("certsBytes is marked non-null but is null", e.getMessage());
@@ -262,10 +304,20 @@ class X509SvidTest {
     @Test
     void testParse_nullKeyByteArray_throwsNullPointerException() throws X509SvidException {
         try {
-            X509Svid.parse("cert".getBytes(), null);
+            X509Svid.parse("cert".getBytes(), null, "");
             fail("should have thrown exception");
         } catch (NullPointerException e) {
             assertEquals("privateKeyBytes is marked non-null but is null", e.getMessage());
+        }
+    }
+
+    @Test
+    void testParse_nullHint_throwsNullPointerException() throws X509SvidException {
+        try {
+            X509Svid.parse("cert".getBytes(), "key".getBytes(), null);
+            fail("should have thrown exception");
+        } catch (NullPointerException e) {
+            assertEquals("hint is marked non-null but is null", e.getMessage());
         }
     }
 
@@ -296,7 +348,7 @@ class X509SvidTest {
             byte[] certBytes = Files.readAllBytes(certPath);
             byte[] keyBytes = Files.readAllBytes(keyPath);
 
-            X509Svid x509Svid = X509Svid.parse(certBytes, keyBytes);
+            X509Svid x509Svid = X509Svid.parse(certBytes, keyBytes, testCase.getHint());
 
             if (StringUtils.isNotBlank(testCase.expectedError)) {
                 fail(String.format("Error was expected: %s", testCase.expectedError));
@@ -309,6 +361,7 @@ class X509SvidTest {
             assertEquals(testCase.expectedNumberOfCerts, x509Svid.getChain().size());
             assertEquals(testCase.expectedSpiffeId, x509Svid.getSpiffeId());
             assertEquals(testCase.expectedPrivateKeyAlgorithm, x509Svid.getPrivateKey().getAlgorithm());
+            assertEquals(testCase.expectedHint, x509Svid.getHint());
 
         } catch (Exception e) {
             if (StringUtils.isBlank(testCase.expectedError)) {
@@ -322,21 +375,25 @@ class X509SvidTest {
     static class TestCase {
         String name;
         String certsPath;
+        String hint;
         String keyPath;
         SpiffeId expectedSpiffeId;
         int expectedNumberOfCerts;
         String expectedPrivateKeyAlgorithm;
+        String expectedHint;
         String expectedError;
 
         @Builder
-        public TestCase(String name, String certsPath, String keyPath, SpiffeId expectedSpiffeId, int expectedNumberOfCerts, String expectedPrivateKeyAlgorithm, String expectedError) {
+        public TestCase(String name, String certsPath, String keyPath, String hint, SpiffeId expectedSpiffeId, int expectedNumberOfCerts, String expectedPrivateKeyAlgorithm, String expectedHint, String expectedError) {
             this.name = name;
             this.certsPath = certsPath;
             this.keyPath = keyPath;
+            this.hint = hint;
             this.expectedSpiffeId = expectedSpiffeId;
             this.expectedNumberOfCerts = expectedNumberOfCerts;
             this.expectedPrivateKeyAlgorithm = expectedPrivateKeyAlgorithm;
             this.expectedError = expectedError;
+            this.expectedHint = expectedHint;
         }
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidTest.java
@@ -238,18 +238,6 @@ class X509SvidTest {
     }
 
     @Test
-    void testParseRawNullHintArgument() {
-        try {
-            X509Svid.parseRaw(new byte[]{}, new byte[]{}, null);
-            fail();
-        } catch (NullPointerException e) {
-            assertEquals("hint is marked non-null but is null", e.getMessage());
-        } catch (X509SvidException e) {
-            fail();
-        }
-    }
-
-    @Test
     void testLoad_FailsCannotReadCertFile() throws URISyntaxException {
         Path keyPath = Paths.get(toUri(keyRSA));
         try {
@@ -308,16 +296,6 @@ class X509SvidTest {
             fail("should have thrown exception");
         } catch (NullPointerException e) {
             assertEquals("privateKeyBytes is marked non-null but is null", e.getMessage());
-        }
-    }
-
-    @Test
-    void testParse_nullHint_throwsNullPointerException() throws X509SvidException {
-        try {
-            X509Svid.parse("cert".getBytes(), "key".getBytes(), null);
-            fail("should have thrown exception");
-        } catch (NullPointerException e) {
-            assertEquals("hint is marked non-null but is null", e.getMessage());
         }
     }
 

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidTest.java
@@ -216,7 +216,7 @@ class X509SvidTest {
     @Test
     void testParseRawNullCertsBytesArgument() {
         try {
-            X509Svid.parseRaw(null, new byte[]{}, "");
+            X509Svid.parseRaw(null, new byte[]{});
             fail();
         } catch (NullPointerException e) {
             assertEquals("certsBytes is marked non-null but is null", e.getMessage());
@@ -228,7 +228,7 @@ class X509SvidTest {
     @Test
     void testParseRawNullPrivateKeyBytesArgument() {
         try {
-            X509Svid.parseRaw(new byte[]{}, null, "");
+            X509Svid.parseRaw(new byte[]{}, null);
             fail();
         } catch (NullPointerException e) {
             assertEquals("privateKeyBytes is marked non-null but is null", e.getMessage());
@@ -282,7 +282,7 @@ class X509SvidTest {
     @Test
     void testParse_nullByteArray_throwsNullPointerException() throws X509SvidException {
         try {
-            X509Svid.parse(null, "key".getBytes(), "");
+            X509Svid.parse(null, "key".getBytes());
             fail("should have thrown exception");
         } catch (NullPointerException e) {
             assertEquals("certsBytes is marked non-null but is null", e.getMessage());
@@ -292,7 +292,7 @@ class X509SvidTest {
     @Test
     void testParse_nullKeyByteArray_throwsNullPointerException() throws X509SvidException {
         try {
-            X509Svid.parse("cert".getBytes(), null, "");
+            X509Svid.parse("cert".getBytes(), null);
             fail("should have thrown exception");
         } catch (NullPointerException e) {
             assertEquals("privateKeyBytes is marked non-null but is null", e.getMessage());

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultJwtSourceTest.java
@@ -88,6 +88,7 @@ class DefaultJwtSourceTest {
             assertNotNull(svid);
             assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
             assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
+            assertEquals("external", svid.getHint());
         } catch (JwtSvidException e) {
             fail(e);
         }
@@ -100,6 +101,7 @@ class DefaultJwtSourceTest {
             assertNotNull(svid);
             assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
             assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
+            assertEquals("external", svid.getHint());
         } catch (JwtSvidException e) {
             fail(e);
         }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientTest.java
@@ -227,7 +227,7 @@ class DefaultWorkloadApiClientTest {
             assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), jwtSvid.getSpiffeId());
             assertTrue(jwtSvid.getAudience().contains("aud1"));
             assertEquals(3, jwtSvid.getAudience().size());
-            assertEquals(jwtSvid.getHint(), "external");
+            assertEquals("external", jwtSvid.getHint());
         } catch (JwtSvidException e) {
             fail(e);
         }
@@ -241,7 +241,7 @@ class DefaultWorkloadApiClientTest {
             assertEquals(SpiffeId.parse("spiffe://example.org/test"), jwtSvid.getSpiffeId());
             assertTrue(jwtSvid.getAudience().contains("aud1"));
             assertEquals(3, jwtSvid.getAudience().size());
-            assertEquals(jwtSvid.getHint(), "external");
+            assertEquals("external", jwtSvid.getHint());
         } catch (JwtSvidException e) {
             fail(e);
         }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultWorkloadApiClientTest.java
@@ -55,7 +55,7 @@ class DefaultWorkloadApiClientTest {
     @Test
     void testNewClient_defaultOptions() throws Exception {
         try {
-            TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/agent.sock" );
+            TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/agent.sock");
             WorkloadApiClient client = DefaultWorkloadApiClient.newClient();
             assertNotNull(client);
         } catch (SocketEndpointAddressException e) {
@@ -100,6 +100,7 @@ class DefaultWorkloadApiClientTest {
         assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), x509Context.getDefaultSvid().getSpiffeId());
         assertNotNull(x509Context.getDefaultSvid().getChain());
         assertNotNull(x509Context.getDefaultSvid().getPrivateKey());
+        assertEquals("external", x509Context.getDefaultSvid().getHint());
         assertNotNull(x509Context.getX509BundleSet());
         try {
             X509Bundle bundle = x509Context.getX509BundleSet().getBundleForTrustDomain(TrustDomain.parse("example.org"));
@@ -134,6 +135,7 @@ class DefaultWorkloadApiClientTest {
         assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), update.getDefaultSvid().getSpiffeId());
         assertNotNull(update.getDefaultSvid().getChain());
         assertNotNull(update.getDefaultSvid().getPrivateKey());
+        assertEquals("external", update.getDefaultSvid().getHint());
         assertNotNull(update.getX509BundleSet());
         try {
             X509Bundle bundle = update.getX509BundleSet().getBundleForTrustDomain(TrustDomain.parse("example.org"));
@@ -225,6 +227,7 @@ class DefaultWorkloadApiClientTest {
             assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), jwtSvid.getSpiffeId());
             assertTrue(jwtSvid.getAudience().contains("aud1"));
             assertEquals(3, jwtSvid.getAudience().size());
+            assertEquals(jwtSvid.getHint(), "external");
         } catch (JwtSvidException e) {
             fail(e);
         }
@@ -238,6 +241,7 @@ class DefaultWorkloadApiClientTest {
             assertEquals(SpiffeId.parse("spiffe://example.org/test"), jwtSvid.getSpiffeId());
             assertTrue(jwtSvid.getAudience().contains("aud1"));
             assertEquals(3, jwtSvid.getAudience().size());
+            assertEquals(jwtSvid.getHint(), "external");
         } catch (JwtSvidException e) {
             fail(e);
         }
@@ -289,9 +293,11 @@ class DefaultWorkloadApiClientTest {
             assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), jwtSvids.get(0).getSpiffeId());
             assertTrue(jwtSvids.get(0).getAudience().contains("aud1"));
             assertEquals(3, jwtSvids.get(0).getAudience().size());
+            assertEquals("external", jwtSvids.get(0).getHint());
             assertEquals(SpiffeId.parse("spiffe://example.org/extra-workload-server"), jwtSvids.get(1).getSpiffeId());
             assertTrue(jwtSvids.get(1).getAudience().contains("aud1"));
             assertEquals(3, jwtSvids.get(1).getAudience().size());
+            assertEquals("", jwtSvids.get(1).getHint());
         } catch (JwtSvidException e) {
             fail(e);
         }
@@ -306,6 +312,7 @@ class DefaultWorkloadApiClientTest {
             assertEquals(SpiffeId.parse("spiffe://example.org/test"), jwtSvids.get(0).getSpiffeId());
             assertTrue(jwtSvids.get(0).getAudience().contains("aud1"));
             assertEquals(3, jwtSvids.get(0).getAudience().size());
+            assertEquals("external", jwtSvids.get(0).getHint());
         } catch (JwtSvidException e) {
             fail(e);
         }
@@ -416,6 +423,7 @@ class DefaultWorkloadApiClientTest {
                 done.countDown();
 
             }
+
             @Override
             public void onError(Throwable e) {
             }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
@@ -82,7 +82,8 @@ class DefaultX509SourceTest {
     void testGetX509Svid() {
         X509Svid x509Svid = x509Source.getX509Svid();
         assertNotNull(x509Svid);
-        assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"),x509Svid.getSpiffeId());
+        assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), x509Svid.getSpiffeId());
+        assertEquals("internal", x509Svid.getHint());
     }
 
     @Test
@@ -123,6 +124,7 @@ class DefaultX509SourceTest {
             fail();
         }
     }
+
     @Test
     void newSource_timeout() throws Exception {
         try {

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApi.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApi.java
@@ -69,8 +69,8 @@ class FakeWorkloadApi extends SpiffeWorkloadAPIImplBase {
                     .setHint("external")
                     .build();
 
-            // This svid should be filtered out by the client because it has a non-unique hint.
-            Workload.X509SVID skipedSVID = Workload.X509SVID
+            // This X.509-SVID should be filtered out by the client because it has a non-unique hint and is not the first X.509-SVID in the response with this hint.
+            Workload.X509SVID skippedSVID = Workload.X509SVID
                     .newBuilder()
                     .setSpiffeId("spiffe://example.org/this0-should-be-filtered-out")
                     .setX509Svid(svidByteString)
@@ -82,7 +82,7 @@ class FakeWorkloadApi extends SpiffeWorkloadAPIImplBase {
             Workload.X509SVIDResponse response = Workload.X509SVIDResponse
                     .newBuilder()
                     .addSvids(svid)
-                    .addSvids(skipedSVID)
+                    .addSvids(skippedSVID)
                     .putFederatedBundles(TrustDomain.parse("domain.test").getName(), federatedByteString)
                     .build();
 
@@ -121,7 +121,7 @@ class FakeWorkloadApi extends SpiffeWorkloadAPIImplBase {
     public void fetchJWTSVID(Workload.JWTSVIDRequest request, StreamObserver<Workload.JWTSVIDResponse> responseObserver) {
         String spiffeId = request.getSpiffeId();
         String extraSpiffeId = "spiffe://example.org/extra-workload-server";
-        String skipedSpiffeId = "spiffe://example.org/this-should-be-filtered-out";
+        String skippedSpiffeId = "spiffe://example.org/this-should-be-filtered-out";
         boolean firstOnly = true;
         if (StringUtils.isBlank(spiffeId)) {
             firstOnly = false;
@@ -157,17 +157,17 @@ class FakeWorkloadApi extends SpiffeWorkloadAPIImplBase {
                 .setSvid(extraToken)
                 .build();
 
-        // This svid should be filtered out by the client because it has a non-unique hint.
-        Workload.JWTSVID skipedJWTSVID = Workload.JWTSVID
+        // This JWT-SVID should be filtered out by the client because it has a non-unique hint and is not the first JWT-SVID in the response with this hint.
+        Workload.JWTSVID skippedJWTSVID = Workload.JWTSVID
                 .newBuilder()
-                .setSpiffeId(skipedSpiffeId)
+                .setSpiffeId(skippedSpiffeId)
                 .setSvid(extraToken)
                 .setHint("external")
                 .build();
 
         Workload.JWTSVIDResponse.Builder builder = Workload.JWTSVIDResponse.newBuilder();
         builder.addSvids(jwtsvid);
-        builder.addSvids(skipedJWTSVID);
+        builder.addSvids(skippedJWTSVID);
         if (!firstOnly) {
             builder.addSvids(extraJwtsvid);
         }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApi.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/FakeWorkloadApi.java
@@ -218,7 +218,7 @@ class FakeWorkloadApi extends SpiffeWorkloadAPIImplBase {
 
         JwtSvid jwtSvid = null;
         try {
-            jwtSvid = JwtSvid.parseInsecure(token, Collections.singleton(audience), "");
+            jwtSvid = JwtSvid.parseInsecure(token, Collections.singleton(audience));
         } catch (JwtSvidException e) {
             responseObserver.onError(new StatusRuntimeException(Status.INVALID_ARGUMENT.withDescription(e.getMessage())));
         }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientStub.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientStub.java
@@ -151,7 +151,7 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
 
         String token = TestUtils.generateToken(claims, keyPair, "authority1");
 
-        return JwtSvid.parseInsecure(token, audParam);
+        return JwtSvid.parseInsecure(token, audParam, "external");
     }
 
 
@@ -185,7 +185,7 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
             Path pathKey = Paths.get(toUri(privateKey));
             byte[] keyBytes = Files.readAllBytes(pathKey);
 
-            return X509Svid.parseRaw(svidBytes, keyBytes);
+            return X509Svid.parseRaw(svidBytes, keyBytes, "internal");
         } catch (X509SvidException | IOException | URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientStub.java
+++ b/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientStub.java
@@ -130,7 +130,7 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
             Path pathKey = Paths.get(toUri(privateKey));
             byte[] keyBytes = Files.readAllBytes(pathKey);
 
-            return X509Svid.parseRaw(svidBytes, keyBytes, "");
+            return X509Svid.parseRaw(svidBytes, keyBytes);
         } catch (X509SvidException | IOException e) {
             throw new RuntimeException(e);
         }

--- a/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientStub.java
+++ b/java-spiffe-helper/src/test/java/io/spiffe/helper/keystore/WorkloadApiClientStub.java
@@ -130,7 +130,7 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
             Path pathKey = Paths.get(toUri(privateKey));
             byte[] keyBytes = Files.readAllBytes(pathKey);
 
-            return X509Svid.parseRaw(svidBytes, keyBytes);
+            return X509Svid.parseRaw(svidBytes, keyBytes, "");
         } catch (X509SvidException | IOException e) {
             throw new RuntimeException(e);
         }

--- a/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeKeyManagerTest.java
+++ b/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeKeyManagerTest.java
@@ -38,11 +38,6 @@ public class SpiffeKeyManagerTest {
     void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        val rootCa = createRootCA("C = US, O = SPIFFE", "spiffe://domain.test");
-        val leaf = createCertificate("C = US, O = SPIRE", "C = US, O = SPIRE", "spiffe://domain.test/workload", rootCa, false);
-
-        X509Svid svid = X509Svid.parseRaw(leaf.getCertificate().getEncoded(), leaf.getKeyPair().getPrivate().getEncoded());
-
         x509Svid = X509Svid.load(
                 Paths.get(toUri("testdata/cert.pem")),
                 Paths.get(toUri("testdata/key.pem")));


### PR DESCRIPTION
## Changes
Add hint field to SVIDs retrieved by workload API client.

## Dependency
This PR depends on https://github.com/spiffe/spire/pull/3993, we must wait until a release containing the changes on workload api server is created before merging this PR.
