### PR TITLE
Add `CachedJwtSource`

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
@@ -64,11 +64,17 @@ public class JwtSvid {
      */
     String token;
 
+    /**
+     * Issued at time of JWT-SVID as present in 'iat' claim.
+     */
+    Date issuedAt;
+
     public static final String HEADER_TYP_JWT = "JWT";
     public static final String HEADER_TYP_JOSE = "JOSE";
 
     private JwtSvid(final SpiffeId spiffeId,
                     final Set<String> audience,
+                    final Date issuedAt,
                     final Date expiry,
                     final Map<String, Object> claims,
                     final String token) {
@@ -77,6 +83,7 @@ public class JwtSvid {
         this.expiry = expiry;
         this.claims = claims;
         this.token = token;
+        this.issuedAt = issuedAt;
     }
 
     /**
@@ -120,6 +127,8 @@ public class JwtSvid {
         val claimsSet = getJwtClaimsSet(signedJwt);
         validateAudience(claimsSet.getAudience(), audience);
 
+        val issuedAt = claimsSet.getIssueTime();
+
         val expirationTime = claimsSet.getExpirationTime();
         validateExpiration(expirationTime);
 
@@ -132,7 +141,8 @@ public class JwtSvid {
         verifySignature(signedJwt, jwtAuthority, algorithm, keyId);
 
         val claimAudience = new HashSet<>(claimsSet.getAudience());
-        return new JwtSvid(spiffeId, claimAudience, expirationTime, claimsSet.getClaims(), token);
+
+        return new JwtSvid(spiffeId, claimAudience, issuedAt, expirationTime, claimsSet.getClaims(), token);
     }
 
     /**
@@ -163,13 +173,16 @@ public class JwtSvid {
         val claimsSet = getJwtClaimsSet(signedJwt);
         validateAudience(claimsSet.getAudience(), audience);
 
+        val issuedAt = claimsSet.getIssueTime();
+
         val expirationTime = claimsSet.getExpirationTime();
         validateExpiration(expirationTime);
 
         val spiffeId = getSpiffeIdOfSubject(claimsSet);
 
         val claimAudience = new HashSet<>(claimsSet.getAudience());
-        return new JwtSvid(spiffeId, claimAudience, expirationTime, claimsSet.getClaims(), token);
+
+        return new JwtSvid(spiffeId, claimAudience, issuedAt, expirationTime, claimsSet.getClaims(), token);
     }
 
     /**

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -237,7 +237,7 @@ public class CachedJwtSource implements JwtSource {
         // even using ConcurrentHashMap, there is a possibility of multiple threads trying to fetch new JWT SVIDs at the same time.
         synchronized (this) {
             // Check again if the jwtSvids map contains the cacheKey, returns the entry if it does exist and the JWT SVID has not past its half lifetime,
-            // if it does not exist or the JWT-SVID has past half its lifetime calls the Workload API to fetch new JWT-SVIDs,
+            // If it does not exist or the JWT-SVID has passed half its lifetime, call the Workload API to fetch new JWT-SVIDs,
             // adds them to the cache map and returns the list of them.
             svidList = jwtSvids.get(cacheKey);
             if (svidList != null && !isTokenPastHalfLifetime(svidList.get(0))) {

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -221,7 +221,7 @@ public class CachedJwtSource implements JwtSource {
         }
     }
 
-    // Check if the jwtSvids map contains the cacheKey, returns it if it does and the JWT SVID has not past its half lifetime.
+    // Check if the jwtSvids map contains the cacheKey, returns it if it does and the JWT SVID has not passed its half lifetime.
     // If the cache does not contain the key or the JWT SVID has past its half lifetime, make a new FetchJWTSVID call to the Workload API,
     // adds the JWT SVIDs to the cache map and returns them.
     // Only one thread can fetch new JWT SVIDs and update the cache at a time.

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -236,7 +236,7 @@ public class CachedJwtSource implements JwtSource {
 
         // even using ConcurrentHashMap, there is a possibility of multiple threads trying to fetch new JWT SVIDs at the same time.
         synchronized (this) {
-            // Check again if the jwtSvids map contains the cacheKey, returns the entry if it does exist and the JWT SVID has not past its half lifetime,
+            // Check again if the jwtSvids map contains the cacheKey, and return the entry if it exists and the JWT SVID has not passed its half lifetime.
             // If it does not exist or the JWT-SVID has passed half its lifetime, call the Workload API to fetch new JWT-SVIDs,
             // adds them to the cache map and returns the list of them.
             svidList = jwtSvids.get(cacheKey);

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -238,7 +238,7 @@ public class CachedJwtSource implements JwtSource {
         synchronized (this) {
             // Check again if the jwtSvids map contains the cacheKey, and return the entry if it exists and the JWT SVID has not passed its half lifetime.
             // If it does not exist or the JWT-SVID has passed half its lifetime, call the Workload API to fetch new JWT-SVIDs,
-            // adds them to the cache map and returns the list of them.
+            // add them to the cache map, and return the list of JWT-SVIDs.
             svidList = jwtSvids.get(cacheKey);
             if (svidList != null && !isTokenPastHalfLifetime(svidList.get(0))) {
                 return svidList;

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -8,13 +8,23 @@ import io.spiffe.exception.*;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.spiffeid.TrustDomain;
 import io.spiffe.svid.jwtsvid.JwtSvid;
-import lombok.*;
+import lombok.NonNull;
+import lombok.SneakyThrows;
 import lombok.extern.java.Log;
+import lombok.val;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import java.io.Closeable;
-import java.time.*;
-import java.util.*;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -240,7 +250,6 @@ public class CachedJwtSource implements JwtSource {
                 svidList = workloadApiClient.fetchJwtSvids(cacheKey.left, audience, extraAudiences);
             }
             jwtSvids.put(cacheKey, svidList);
-
             return svidList;
         }
     }

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -128,12 +128,12 @@ public class CachedJwtSource implements JwtSource {
      * @throws JwtSvidException
      */
     @Override
-    public JwtSvid fetchJwtSvid(String audience, String... extraAudiences) throws JwtSvidException {
+    public JwtSvid fetchJwtSvid(final String audience, final String... extraAudiences) throws JwtSvidException {
         if (isClosed()) {
             throw new IllegalStateException("JWT SVID source is closed");
         }
 
-        return getJwtSvids(null, audience, extraAudiences).get(0);
+        return getJwtSvids(audience, extraAudiences).get(0);
     }
 
     /**
@@ -161,12 +161,12 @@ public class CachedJwtSource implements JwtSource {
      * @throws IllegalStateException if the source is closed
      */
     @Override
-    public List<JwtSvid> fetchJwtSvids(String audience, String... extraAudiences) throws JwtSvidException {
+    public List<JwtSvid> fetchJwtSvids(final String audience, final String... extraAudiences) throws JwtSvidException {
         if (isClosed()) {
             throw new IllegalStateException("JWT SVID source is closed");
         }
 
-        return getJwtSvids(null, audience, extraAudiences);
+        return getJwtSvids(audience, extraAudiences);
     }
 
     /**
@@ -252,6 +252,10 @@ public class CachedJwtSource implements JwtSource {
             jwtSvids.put(cacheKey, svidList);
             return svidList;
         }
+    }
+
+    private List<JwtSvid> getJwtSvids(String audience, String... extraAudiences) throws JwtSvidException {
+        return getJwtSvids(null, audience, extraAudiences);
     }
 
     private static Set<String> getAudienceSet(String audience, String[] extraAudiences) {

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -224,6 +224,7 @@ public class CachedJwtSource implements JwtSource {
             return svidList;
         }
 
+        // even using ConcurrentHashMap, there is a possibility of multiple threads trying to fetch new JWT SVIDs at the same time.
         synchronized (this) {
             // Check again if the jwtSvids map contains the cacheKey, returns the entry if it does exist and the JWT SVID has not past its half lifetime,
             // if it does not exist or the JWT-SVID has past half its lifetime calls the Workload API to fetch new JWT-SVIDs,

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -222,7 +222,7 @@ public class CachedJwtSource implements JwtSource {
     }
 
     // Check if the jwtSvids map contains the cacheKey, returns it if it does and the JWT SVID has not passed its half lifetime.
-    // If the cache does not contain the key or the JWT SVID has past its half lifetime, make a new FetchJWTSVID call to the Workload API,
+    // If the cache does not contain the key or the JWT SVID has passed its half lifetime, make a new FetchJWTSVID call to the Workload API,
     // adds the JWT SVIDs to the cache map and returns them.
     // Only one thread can fetch new JWT SVIDs and update the cache at a time.
     private List<JwtSvid> getJwtSvids(SpiffeId subject, String audience, String... extraAudiences) throws JwtSvidException {

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -35,7 +35,7 @@ public class CachedJwtSource implements JwtSource {
     static final Duration DEFAULT_TIMEOUT =
             Duration.parse(System.getProperty(TIMEOUT_SYSTEM_PROPERTY, "PT0S"));
 
-    // Synchronized map of JWT SVIDs, keyed by a pair of SPIFFE ID and Set of audiences strings.
+    // Synchronized map of JWT SVIDs, keyed by a pair of SPIFFE ID and a Set of audiences strings.
     // This map is used to cache the JWT SVIDs and avoid fetching them from the Workload API.
     private final
     Map<ImmutablePair<SpiffeId, Set<String>>, List<JwtSvid>> jwtSvids = new ConcurrentHashMap<>();

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -119,7 +119,7 @@ public class CachedJwtSource implements JwtSource {
     }
 
     /**
-     * Fetches a JWT SVID for the given audience. The JWT SVID is cached and
+     * Fetches a JWT SVID for the given audiences. The JWT SVID is cached and
      * returned from cache if it has still at least half of its lifetime.
      *
      * @param audience       the audience

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -120,7 +120,7 @@ public class CachedJwtSource implements JwtSource {
 
     /**
      * Fetches a JWT SVID for the given audiences. The JWT SVID is cached and
-     * returned from cache if it has still at least half of its lifetime.
+     * returned from the cache if it still has at least half of its lifetime.
      *
      * @param audience       the audience
      * @param extraAudiences a list of extra audiences as an array of String

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -81,7 +81,7 @@ public class CachedJwtSource implements JwtSource {
 
     /**
      * Creates a new JWT source. It blocks until the initial update with the JWT bundles
-     * has been received from the Workload API, doing retries with a backoff exponential policy,
+     * has been received from the Workload API, doing retries with an exponential backoff policy,
      * or until the initTimeout has expired.
      * <p>
      * If the timeout is not provided in the options, the default timeout is read from the

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -228,7 +228,7 @@ public class CachedJwtSource implements JwtSource {
         audiences[0] = audience;
         System.arraycopy(extraAudiences, 0, audiences, 1, extraAudiences.length);
         Arrays.sort(audiences);
-        return String.join(",", audiences);
+        return String.join("", audiences);
     }
 
     // Check if the jwtSvids map contains the cacheKey, returns it if it does and the JWT SVID has not past its half lifetime.
@@ -241,8 +241,9 @@ public class CachedJwtSource implements JwtSource {
         }
 
         synchronized (this) {
-            // Check again if the jwtSvids map contains the cacheKey, returns it if it does and the JWT SVID has not past its half lifetime,
-            // if not, fetches a new one, adds it to the cache map and returns it.
+            // Check again if the jwtSvids map contains the cacheKey, returns the entry if it does exist and the JWT SVID has not past its half lifetime,
+            // if it does not exist or the JWT-SVID has past half its lifetime calls the Workload API to fetch new JWT-SVIDs,
+            // adds them to the cache map and returns the list of them.
             svidList = jwtSvids.get(cacheKey);
             if (svidList != null && !isTokenPastHalfLifetime(svidList.get(0))) {
                 return svidList;

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/JwtSourceOptions.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/JwtSourceOptions.java
@@ -1,0 +1,43 @@
+package io.spiffe.workloadapi;
+
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Duration;
+
+/**
+ * Options to configure a {@link JwtSource}.
+ * <p>
+ * <code>spiffeSocketPath</code> Address to the Workload API, if it is not set, the default address will be used.
+ * <p>
+ * <code>initTimeout</code> Timeout for initializing the instance. If it is not defined, the timeout is read
+ * from the System property `spiffe.newJwtSource.timeout'. If this is also not defined, no default timeout is applied.
+ * <p>
+ * <code>workloadApiClient</code> A custom instance of a {@link WorkloadApiClient}, if it is not set,
+ * a new client will be created.
+ */
+@Data
+public class JwtSourceOptions {
+
+    @Setter(AccessLevel.PUBLIC)
+    private String spiffeSocketPath;
+
+    @Setter(AccessLevel.PUBLIC)
+    private Duration initTimeout;
+
+    @Setter(AccessLevel.PUBLIC)
+    private WorkloadApiClient workloadApiClient;
+
+    @Builder
+    public JwtSourceOptions(
+            final String spiffeSocketPath,
+            final WorkloadApiClient workloadApiClient,
+            final Duration initTimeout) {
+        this.spiffeSocketPath = spiffeSocketPath;
+        this.workloadApiClient = workloadApiClient;
+        this.initTimeout = initTimeout;
+    }
+}

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
@@ -124,6 +124,7 @@ class JwtSvidParseAndValidateTest {
         jwtBundle.putJwtAuthority("authority3", key3.getPublic());
 
         SpiffeId spiffeId = trustDomain.newSpiffeId("host");
+        Date issuedAt = new Date();
         Date expiration = new Date(System.currentTimeMillis() +  (60 * 60 * 1000));
         Set<String> audience = new HashSet<String>() {{add("audience1"); add("audience2");}};
 
@@ -139,6 +140,7 @@ class JwtSvidParseAndValidateTest {
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
+                                issuedAt,
                                 expiration,
                                 claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", JwtSvid.HEADER_TYP_JOSE) ))
                         .build()),
@@ -151,6 +153,7 @@ class JwtSvidParseAndValidateTest {
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
+                                issuedAt,
                                 expiration,
                                 claims.getClaims(), TestUtils.generateToken(claims, key3, "authority3", JwtSvid.HEADER_TYP_JWT)))
                         .build()),
@@ -163,6 +166,7 @@ class JwtSvidParseAndValidateTest {
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
+                                issuedAt,
                                 expiration,
                                 claims.getClaims(), TestUtils.generateToken(claims, key3, "authority3")))
                         .build())

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
@@ -112,6 +112,7 @@ class JwtSvidParseInsecureTest {
 
         SpiffeId spiffeId = trustDomain.newSpiffeId("host");
         Date expiration = new Date(System.currentTimeMillis() + 3600000);
+        Date issuedAt = new Date();
         Set<String> audience = Collections.singleton("audience");
 
         JWTClaimsSet claims = TestUtils.buildJWTClaimSet(audience, spiffeId.toString(), expiration);
@@ -125,6 +126,7 @@ class JwtSvidParseInsecureTest {
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
+                                issuedAt,
                                 expiration,
                                 claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", JwtSvid.HEADER_TYP_JWT)))
                         .build()),
@@ -136,6 +138,7 @@ class JwtSvidParseInsecureTest {
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
+                                issuedAt,
                                 expiration,
                                 claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", JwtSvid.HEADER_TYP_JWT)))
                         .build()),
@@ -147,6 +150,7 @@ class JwtSvidParseInsecureTest {
                         .expectedJwtSvid(newJwtSvidInstance(
                                 trustDomain.newSpiffeId("host"),
                                 audience,
+                                issuedAt,
                                 expiration,
                                 claims.getClaims(), TestUtils.generateToken(claims, key1, "authority1", "")))
                         .build()));
@@ -234,13 +238,14 @@ class JwtSvidParseInsecureTest {
 
     static JwtSvid newJwtSvidInstance(final SpiffeId spiffeId,
                                       final Set<String> audience,
+                                      final Date issuedAt,
                                       final Date expiry,
                                       final Map<String, Object> claims,
                                       final String token) {
         val constructor = JwtSvid.class.getDeclaredConstructors()[0];
         constructor.setAccessible(true);
         try {
-            return (JwtSvid) constructor.newInstance(spiffeId, audience, expiry, claims, token);
+            return (JwtSvid) constructor.newInstance(spiffeId, audience, issuedAt, expiry, claims, token);
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
@@ -1,0 +1,404 @@
+package io.spiffe.workloadapi;
+
+import com.google.common.collect.Sets;
+import io.spiffe.bundle.jwtbundle.JwtBundle;
+import io.spiffe.exception.BundleNotFoundException;
+import io.spiffe.exception.JwtSourceException;
+import io.spiffe.exception.JwtSvidException;
+import io.spiffe.exception.SocketEndpointAddressException;
+import io.spiffe.spiffeid.SpiffeId;
+import io.spiffe.spiffeid.TrustDomain;
+import io.spiffe.svid.jwtsvid.JwtSvid;
+import io.spiffe.utils.TestUtils;
+import lombok.val;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CachedJwtSourceTest {
+    private JwtSource jwtSource;
+    private WorkloadApiClientStub workloadApiClient;
+    private WorkloadApiClientErrorStub workloadApiClientErrorStub;
+
+    @BeforeEach
+    void setUp() throws JwtSourceException, SocketEndpointAddressException {
+        workloadApiClient = new WorkloadApiClientStub();
+        JwtSourceOptions options = JwtSourceOptions.builder().workloadApiClient(workloadApiClient).build();
+        System.setProperty(DefaultJwtSource.TIMEOUT_SYSTEM_PROPERTY, "PT1S");
+        jwtSource = CachedJwtSource.newSource(options);
+        workloadApiClientErrorStub = new WorkloadApiClientErrorStub();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        jwtSource.close();
+    }
+
+    @Test
+    void testGetBundleForTrustDomain() {
+        try {
+            JwtBundle bundle = jwtSource.getBundleForTrustDomain(TrustDomain.parse("example.org"));
+            assertNotNull(bundle);
+            assertEquals(TrustDomain.parse("example.org"), bundle.getTrustDomain());
+        } catch (BundleNotFoundException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testGetBundleForTrustDomain_nullParam() {
+        try {
+            jwtSource.getBundleForTrustDomain(null);
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("trustDomain is marked non-null but is null", e.getMessage());
+        } catch (BundleNotFoundException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void testGetBundleForTrustDomain_SourceIsClosed_ThrowsIllegalStateException() throws IOException {
+        jwtSource.close();
+        try {
+            jwtSource.getBundleForTrustDomain(TrustDomain.parse("example.org"));
+            fail("expected exception");
+        } catch (IllegalStateException e) {
+            assertEquals("JWT bundle source is closed", e.getMessage());
+            assertTrue(workloadApiClient.closed);
+        } catch (BundleNotFoundException e) {
+            fail("not expected exception", e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidWithSubject() {
+        try {
+            JwtSvid svid = jwtSource.fetchJwtSvid(SpiffeId.parse("spiffe://example.org/workload-server"), "aud1", "aud2", "aud3");
+            assertNotNull(svid);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidWithSubject_ReturnFromCache() {
+        try {
+            JwtSvid svid = jwtSource.fetchJwtSvid(SpiffeId.parse("spiffe://example.org/workload-server"), "aud3", "aud2", "aud1");
+            assertNotNull(svid);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
+            assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
+
+            // call again to get from cache changing the order of the audiences
+            svid = jwtSource.fetchJwtSvid(SpiffeId.parse("spiffe://example.org/workload-server"), "aud1", "aud2", "aud3");
+            assertNotNull(svid);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
+            assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
+
+            // call again to get from cache changing the order of the audiences
+            svid = jwtSource.fetchJwtSvid(SpiffeId.parse("spiffe://example.org/workload-server"), "aud2", "aud3", "aud1");
+            assertNotNull(svid);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
+            assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
+
+            // call again using different audience
+            svid = jwtSource.fetchJwtSvid(SpiffeId.parse("spiffe://example.org/workload-server"), "other-audience");
+            assertNotNull(svid);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
+            assertEquals(Sets.newHashSet("other-audience"), svid.getAudience());
+            assertEquals(2, workloadApiClient.getFetchJwtSvidCallCount());
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidWithoutSubject() {
+        try {
+            JwtSvid svid = jwtSource.fetchJwtSvid("aud1", "aud2", "aud3");
+            assertNotNull(svid);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidWithoutSubject_ReturnFromCache() {
+        try {
+            JwtSvid svid = jwtSource.fetchJwtSvid("aud1", "aud2", "aud3");
+            assertNotNull(svid);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
+            assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
+
+            // call again to get from cache changing the order of the audiences
+            svid = jwtSource.fetchJwtSvid("aud3", "aud2", "aud1");
+            assertNotNull(svid);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
+            assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
+
+            // call again using different audience
+            svid = jwtSource.fetchJwtSvid("other-audience");
+            assertNotNull(svid);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svid.getSpiffeId());
+            assertEquals(Sets.newHashSet("other-audience"), svid.getAudience());
+            assertEquals(2, workloadApiClient.getFetchJwtSvidCallCount());
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvid_SourceIsClosed_ThrowsIllegalStateException() throws IOException {
+        jwtSource.close();
+        try {
+            jwtSource.fetchJwtSvid("aud1", "aud2", "aud3");
+            fail("expected exception");
+        } catch (IllegalStateException e) {
+            assertEquals("JWT SVID source is closed", e.getMessage());
+            assertTrue(workloadApiClient.closed);
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidWithSubject_SourceIsClosed_ThrowsIllegalStateException() throws IOException {
+        jwtSource.close();
+        try {
+            jwtSource.fetchJwtSvid(SpiffeId.parse("spiffe://example.org/workload-server"), "aud1", "aud2", "aud3");
+            fail("expected exception");
+        } catch (IllegalStateException e) {
+            assertEquals("JWT SVID source is closed", e.getMessage());
+            assertTrue(workloadApiClient.closed);
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+
+    @Test
+    void testFetchJwtSvidsWithSubject() {
+        try {
+            List<JwtSvid> svids = jwtSource.fetchJwtSvids(SpiffeId.parse("spiffe://example.org/workload-server"), "aud1", "aud2", "aud3");
+            assertNotNull(svids);
+            assertEquals(1, svids.size());
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svids.get(0).getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svids.get(0).getAudience());
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidsWithSubject_ReturnFromCache() {
+        try {
+            List<JwtSvid> svids = jwtSource.fetchJwtSvids(SpiffeId.parse("spiffe://example.org/workload-server"), "aud1", "aud2", "aud3");
+            assertNotNull(svids);
+            assertEquals(1, svids.size());
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svids.get(0).getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svids.get(0).getAudience());
+            assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
+
+            // call again to get from cache changing the order of the audiences
+            svids = jwtSource.fetchJwtSvids(SpiffeId.parse("spiffe://example.org/workload-server"), "aud1", "aud2", "aud3");
+            assertNotNull(svids);
+            assertEquals(1, svids.size());
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svids.get(0).getSpiffeId());
+            assertEquals(Sets.newHashSet("aud3", "aud2", "aud1"), svids.get(0).getAudience());
+            assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
+
+            // call again using different audience
+            svids = jwtSource.fetchJwtSvids(SpiffeId.parse("spiffe://example.org/workload-server"), "other-audience");
+            assertNotNull(svids);
+            assertEquals(1, svids.size());
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svids.get(0).getSpiffeId());
+            assertEquals(Sets.newHashSet("other-audience"), svids.get(0).getAudience());
+            assertEquals(2, workloadApiClient.getFetchJwtSvidCallCount());
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidsWithoutSubject() {
+        try {
+            List<JwtSvid> svids = jwtSource.fetchJwtSvids("aud1", "aud2", "aud3");
+            assertNotNull(svids);
+            assertEquals(svids.size(), 2);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svids.get(0).getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svids.get(0).getAudience());
+            assertEquals(SpiffeId.parse("spiffe://example.org/extra-workload-server"), svids.get(1).getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svids.get(1).getAudience());
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidsWithoutSubject_ReturnFromCache() {
+        try {
+            List<JwtSvid> svids = jwtSource.fetchJwtSvids("aud1", "aud2", "aud3");
+            assertNotNull(svids);
+            assertEquals(svids.size(), 2);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svids.get(0).getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svids.get(0).getAudience());
+            assertEquals(SpiffeId.parse("spiffe://example.org/extra-workload-server"), svids.get(1).getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svids.get(1).getAudience());
+            assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
+
+            // call again to get from cache changing the order of the audiences
+            svids = jwtSource.fetchJwtSvids("aud2", "aud3", "aud1");
+            assertNotNull(svids);
+            assertEquals(svids.size(), 2);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svids.get(0).getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svids.get(0).getAudience());
+            assertEquals(SpiffeId.parse("spiffe://example.org/extra-workload-server"), svids.get(1).getSpiffeId());
+            assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svids.get(1).getAudience());
+            assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
+
+            // call again using different audience
+            svids = jwtSource.fetchJwtSvids("other-audience");
+            assertNotNull(svids);
+            assertEquals(svids.size(), 2);
+            assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svids.get(0).getSpiffeId());
+            assertEquals(Sets.newHashSet("other-audience"), svids.get(0).getAudience());
+            assertEquals(SpiffeId.parse("spiffe://example.org/extra-workload-server"), svids.get(1).getSpiffeId());
+            assertEquals(Sets.newHashSet("other-audience"), svids.get(1).getAudience());
+            assertEquals(2, workloadApiClient.getFetchJwtSvidCallCount());
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvids_SourceIsClosed_ThrowsIllegalStateException() throws IOException {
+        jwtSource.close();
+        try {
+            jwtSource.fetchJwtSvids("aud1", "aud2", "aud3");
+            fail("expected exception");
+        } catch (IllegalStateException e) {
+            assertEquals("JWT SVID source is closed", e.getMessage());
+            assertTrue(workloadApiClient.closed);
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testFetchJwtSvidsWithSubject_SourceIsClosed_ThrowsIllegalStateException() throws IOException {
+        jwtSource.close();
+        try {
+            jwtSource.fetchJwtSvids(SpiffeId.parse("spiffe://example.org/workload-server"), "aud1", "aud2", "aud3");
+            fail("expected exception");
+        } catch (IllegalStateException e) {
+            assertEquals("JWT SVID source is closed", e.getMessage());
+            assertTrue(workloadApiClient.closed);
+        } catch (JwtSvidException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void newSource_success() {
+        val options = JwtSourceOptions
+                .builder()
+                .workloadApiClient(workloadApiClient)
+                .initTimeout(Duration.ofSeconds(0))
+                .build();
+        try {
+            JwtSource jwtSource = DefaultJwtSource.newSource(options);
+            assertNotNull(jwtSource);
+        } catch (SocketEndpointAddressException | JwtSourceException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void newSource_nullParam() {
+        try {
+            DefaultJwtSource.newSource(null);
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("options is marked non-null but is null", e.getMessage());
+        } catch (SocketEndpointAddressException | JwtSourceException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void newSource_errorFetchingJwtBundles() {
+        val options = JwtSourceOptions
+                .builder()
+                .workloadApiClient(workloadApiClientErrorStub)
+                .spiffeSocketPath("unix:/tmp/test")
+                .build();
+        try {
+            DefaultJwtSource.newSource(options);
+            fail();
+        } catch (JwtSourceException e) {
+            assertEquals("Error creating JWT source", e.getMessage());
+            assertEquals("Error fetching JwtBundleSet", e.getCause().getMessage());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    void newSource_FailsBecauseOfTimeOut() throws Exception {
+        try {
+            val options = JwtSourceOptions
+                    .builder()
+                    .spiffeSocketPath("unix:/tmp/test")
+                    .build();
+            DefaultJwtSource.newSource(options);
+            fail();
+        } catch (JwtSourceException e) {
+            assertEquals("Error creating JWT source", e.getMessage());
+            assertEquals("Timeout waiting for JWT bundles update", e.getCause().getMessage());
+        } catch (SocketEndpointAddressException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void newSource_DefaultSocketAddress() throws Exception {
+        try {
+            TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test");
+            DefaultJwtSource.newSource();
+            fail();
+        } catch (JwtSourceException e) {
+            assertEquals("Error creating JWT source", e.getMessage());
+        } catch (SocketEndpointAddressException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void newSource_noSocketAddress() throws Exception {
+        try {
+            // just in case it's defined in the environment
+            TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "");
+            DefaultJwtSource.newSource();
+            fail();
+        } catch (SocketEndpointAddressException e) {
+            fail();
+        } catch (IllegalStateException e) {
+            assertEquals("Endpoint Socket Address Environment Variable is not set: SPIFFE_ENDPOINT_SOCKET", e.getMessage());
+        }
+    }
+}

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
@@ -141,6 +141,9 @@ class CachedJwtSourceTest {
             assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
             assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
 
+            // set clock forwards but not enough to expire the JWT SVID in the cache
+            jwtSource.setClock(clock.offset(clock, JWT_TTL.dividedBy(2).minus(Duration.ofSeconds(1))));
+
             // call again to get from cache, fetchJwtSvid call count should not change
             svid = jwtSource.fetchJwtSvid(SpiffeId.parse("spiffe://example.org/workload-server"), "aud1", "aud2", "aud3");
             assertNotNull(svid);
@@ -211,6 +214,9 @@ class CachedJwtSourceTest {
             assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
             assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
 
+            // set clock forwards but not enough to expire the JWT SVID in the cache
+            jwtSource.setClock(clock.offset(clock, JWT_TTL.dividedBy(2).minus(Duration.ofSeconds(1))));
+
             // call again to get from cache, fetchJwtSvid call count should not change
             svid = jwtSource.fetchJwtSvid("aud3", "aud2", "aud1");
             assertNotNull(svid);
@@ -218,7 +224,7 @@ class CachedJwtSourceTest {
             assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
             assertEquals(1, workloadApiClient.getFetchJwtSvidCallCount());
 
-            // set clock to expire the JWT SVID in the cache
+            // set clock forwards to expire the JWT SVID in the cache
             jwtSource.setClock(clock.offset(clock, JWT_TTL.dividedBy(2).plus(Duration.ofSeconds(1))));
 
             // call again, fetchJwtSvid call count should increase

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
@@ -172,7 +172,7 @@ class CachedJwtSourceTest {
     }
 
     @Test
-    void testfFetchJwtSvidWithSubject_JwtSvidExpiredInCache_MultipleThreads() {
+    void testFetchJwtSvidWithSubject_JwtSvidExpiredInCache_MultipleThreads() {
         // test fetchJwtSvid with several threads trying to read and write the cache
         // at the same time, the cache should be updated only once
         try {

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
@@ -126,7 +126,7 @@ class CachedJwtSourceTest {
             assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svid.getAudience());
             assertEquals(2, workloadApiClient.getFetchJwtSvidCallCount());
 
-            // call again using different audience
+            // call again using the same audiences
             svid = jwtSource.fetchJwtSvid(SpiffeId.parse("spiffe://example.org/extra-workload-server"), "aud1", "aud2", "aud3");
             assertNotNull(svid);
             assertEquals(SpiffeId.parse("spiffe://example.org/extra-workload-server"), svid.getSpiffeId());

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultJwtSourceTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-class JwtSourceTest {
+class DefaultJwtSourceTest {
 
     private JwtSource jwtSource;
     private WorkloadApiClientStub workloadApiClient;
@@ -33,7 +33,7 @@ class JwtSourceTest {
     @BeforeEach
     void setUp() throws JwtSourceException, SocketEndpointAddressException {
         workloadApiClient = new WorkloadApiClientStub();
-        DefaultJwtSource.JwtSourceOptions options = DefaultJwtSource.JwtSourceOptions.builder().workloadApiClient(workloadApiClient).build();
+        JwtSourceOptions options = JwtSourceOptions.builder().workloadApiClient(workloadApiClient).build();
         System.setProperty(DefaultJwtSource.TIMEOUT_SYSTEM_PROPERTY, "PT1S");
         jwtSource = DefaultJwtSource.newSource(options);
         workloadApiClientErrorStub = new WorkloadApiClientErrorStub();
@@ -152,7 +152,7 @@ class JwtSourceTest {
         try {
             List<JwtSvid> svids = jwtSource.fetchJwtSvids("aud1", "aud2", "aud3");
             assertNotNull(svids);
-            assertEquals(svids.size(), 2);
+            assertEquals(2, svids.size());
             assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"), svids.get(0).getSpiffeId());
             assertEquals(Sets.newHashSet("aud1", "aud2", "aud3"), svids.get(0).getAudience());
             assertEquals(SpiffeId.parse("spiffe://example.org/extra-workload-server"), svids.get(1).getSpiffeId());
@@ -193,7 +193,7 @@ class JwtSourceTest {
 
     @Test
     void newSource_success() {
-        val options = DefaultJwtSource.JwtSourceOptions
+        val options = JwtSourceOptions
                 .builder()
                 .workloadApiClient(workloadApiClient)
                 .initTimeout(Duration.ofSeconds(0))
@@ -220,7 +220,7 @@ class JwtSourceTest {
 
     @Test
     void newSource_errorFetchingJwtBundles() {
-        val options = DefaultJwtSource.JwtSourceOptions
+        val options = JwtSourceOptions
                 .builder()
                 .workloadApiClient(workloadApiClientErrorStub)
                 .spiffeSocketPath("unix:/tmp/test")
@@ -239,7 +239,7 @@ class JwtSourceTest {
     @Test
     void newSource_FailsBecauseOfTimeOut() throws Exception {
         try {
-            val options = DefaultJwtSource.JwtSourceOptions
+            val options = JwtSourceOptions
                     .builder()
                     .spiffeSocketPath("unix:/tmp/test")
                     .build();

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
@@ -6,7 +6,6 @@ import io.spiffe.exception.SocketEndpointAddressException;
 import io.spiffe.exception.X509SourceException;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.spiffeid.TrustDomain;
-import io.spiffe.svid.jwtsvid.JwtSvid;
 import io.spiffe.svid.x509svid.X509Svid;
 import io.spiffe.utils.TestUtils;
 import lombok.val;
@@ -85,7 +84,6 @@ class DefaultX509SourceTest {
         assertNotNull(x509Svid);
         assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"),x509Svid.getSpiffeId());
     }
-
 
     @Test
     void testGetX509Svid_SourceIsClosed_ThrowsIllegalStateException() {

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/DefaultX509SourceTest.java
@@ -6,6 +6,7 @@ import io.spiffe.exception.SocketEndpointAddressException;
 import io.spiffe.exception.X509SourceException;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.spiffeid.TrustDomain;
+import io.spiffe.svid.jwtsvid.JwtSvid;
 import io.spiffe.svid.x509svid.X509Svid;
 import io.spiffe.utils.TestUtils;
 import lombok.val;
@@ -84,6 +85,7 @@ class DefaultX509SourceTest {
         assertNotNull(x509Svid);
         assertEquals(SpiffeId.parse("spiffe://example.org/workload-server"),x509Svid.getSpiffeId());
     }
+
 
     @Test
     void testGetX509Svid_SourceIsClosed_ThrowsIllegalStateException() {

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientStub.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/WorkloadApiClientStub.java
@@ -36,6 +36,8 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
     final SpiffeId subject = SpiffeId.parse("spiffe://example.org/workload-server");
     final SpiffeId extraSubject = SpiffeId.parse("spiffe://example.org/extra-workload-server");
 
+    int fetchJwtSvidCallCount = 0;
+
     boolean closed;
 
     @Override
@@ -62,16 +64,19 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
 
     @Override
     public JwtSvid fetchJwtSvid(@NonNull final String audience, final String... extraAudience) throws JwtSvidException {
+        fetchJwtSvidCallCount++;
         return generateJwtSvid(subject, audience, extraAudience);
     }
 
     @Override
     public JwtSvid fetchJwtSvid(@NonNull final SpiffeId subject, @NonNull final String audience, final String... extraAudience) throws JwtSvidException {
+        fetchJwtSvidCallCount++;
         return generateJwtSvid(subject, audience, extraAudience);
     }
 
     @Override
     public List<JwtSvid> fetchJwtSvids(@NonNull String audience, String... extraAudience) throws JwtSvidException {
+        fetchJwtSvidCallCount++;
         List<JwtSvid> svids = new ArrayList<>();
         svids.add(generateJwtSvid(subject, audience, extraAudience));
         svids.add(generateJwtSvid(extraSubject, audience, extraAudience));
@@ -80,6 +85,7 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
 
     @Override
     public List<JwtSvid> fetchJwtSvids(@NonNull SpiffeId subject, @NonNull String audience, String... extraAudience) throws JwtSvidException {
+        fetchJwtSvidCallCount++;
         List<JwtSvid> svids = new ArrayList<>();
         svids.add(generateJwtSvid(subject, audience, extraAudience));
         return svids;
@@ -177,5 +183,13 @@ public class WorkloadApiClientStub implements WorkloadApiClient {
         } catch (X509SvidException | IOException | URISyntaxException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    void resetFetchJwtSvidCallCount() {
+        fetchJwtSvidCallCount = 0;
+    }
+
+    int getFetchJwtSvidCallCount() {
+        return fetchJwtSvidCallCount;
     }
 }

--- a/java-spiffe-core/src/testFixtures/java/io/spiffe/utils/TestUtils.java
+++ b/java-spiffe-core/src/testFixtures/java/io/spiffe/utils/TestUtils.java
@@ -101,6 +101,7 @@ public class TestUtils {
     public static JWTClaimsSet buildJWTClaimSetFromClaimsMap(Map<String, Object> claims) {
         return new JWTClaimsSet.Builder()
                 .subject((String) claims.get("sub"))
+                .issueTime((Date) claims.get("iat"))
                 .expirationTime((Date) claims.get("exp"))
                 .audience((List<String>) claims.get("aud"))
                 .build();


### PR DESCRIPTION
This PR adds a new implementation of `JwtSource` named `CachedJwtSource` that acts as a source of SPIFFE JWT SVIDs and Bundles, that caches the JWT SVIDs based on their subjects and audiences, and avoids unnecessary calls to the Workload API.

Fixes #115 
