### PR TITLE
Fix CachedJwtSource tests

### DIFF
--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
@@ -40,7 +40,7 @@ class CachedJwtSourceTest {
     void setUp() throws JwtSourceException, SocketEndpointAddressException {
         workloadApiClient = new WorkloadApiClientStub();
         JwtSourceOptions options = JwtSourceOptions.builder().workloadApiClient(workloadApiClient).build();
-        System.setProperty(DefaultJwtSource.TIMEOUT_SYSTEM_PROPERTY, "PT1S");
+        System.setProperty(CachedJwtSource.TIMEOUT_SYSTEM_PROPERTY, "PT1S");
         jwtSource = (CachedJwtSource) CachedJwtSource.newSource(options);
         workloadApiClientErrorStub = new WorkloadApiClientErrorStub();
 
@@ -439,7 +439,7 @@ class CachedJwtSourceTest {
                 .initTimeout(Duration.ofSeconds(0))
                 .build();
         try {
-            JwtSource jwtSource = DefaultJwtSource.newSource(options);
+            JwtSource jwtSource = CachedJwtSource.newSource(options);
             assertNotNull(jwtSource);
         } catch (SocketEndpointAddressException | JwtSourceException e) {
             fail(e);
@@ -449,7 +449,7 @@ class CachedJwtSourceTest {
     @Test
     void newSource_nullParam() {
         try {
-            DefaultJwtSource.newSource(null);
+            CachedJwtSource.newSource(null);
             fail();
         } catch (NullPointerException e) {
             assertEquals("options is marked non-null but is null", e.getMessage());
@@ -466,7 +466,7 @@ class CachedJwtSourceTest {
                 .spiffeSocketPath("unix:/tmp/test")
                 .build();
         try {
-            DefaultJwtSource.newSource(options);
+            CachedJwtSource.newSource(options);
             fail();
         } catch (JwtSourceException e) {
             assertEquals("Error creating JWT source", e.getMessage());
@@ -483,7 +483,7 @@ class CachedJwtSourceTest {
                     .builder()
                     .spiffeSocketPath("unix:/tmp/test")
                     .build();
-            DefaultJwtSource.newSource(options);
+            CachedJwtSource.newSource(options);
             fail();
         } catch (JwtSourceException e) {
             assertEquals("Error creating JWT source", e.getMessage());
@@ -497,7 +497,7 @@ class CachedJwtSourceTest {
     void newSource_DefaultSocketAddress() throws Exception {
         try {
             TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "unix:/tmp/test");
-            DefaultJwtSource.newSource();
+            CachedJwtSource.newSource();
             fail();
         } catch (JwtSourceException e) {
             assertEquals("Error creating JWT source", e.getMessage());
@@ -511,7 +511,7 @@ class CachedJwtSourceTest {
         try {
             // just in case it's defined in the environment
             TestUtils.setEnvironmentVariable(Address.SOCKET_ENV_VARIABLE, "");
-            DefaultJwtSource.newSource();
+            CachedJwtSource.newSource();
             fail();
         } catch (SocketEndpointAddressException e) {
             fail();


### PR DESCRIPTION
Fix some tests in `CachedJwtSourceTest` that were using `DefaultJwtSource` instead of `CachedJwtSource`.