### PR TITLE
Fix Compatibility Issue with gRPC 1.61.0

### DIFF
--- a/java-spiffe-core/build.gradle
+++ b/java-spiffe-core/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     implementation group: 'io.grpc', name: 'grpc-protobuf', version: "${grpcVersion}"
     implementation group: 'io.grpc', name: 'grpc-stub', version: "${grpcVersion}"
     implementation group: 'io.grpc', name: 'grpc-inprocess', version: "${grpcVersion}"
+    implementation group: 'io.grpc', name: 'grpc-util', version: "${grpcVersion}"
     testImplementation group: 'io.grpc', name: 'grpc-testing', version: "${grpcVersion}"
     compileOnly group: 'org.apache.tomcat', name: 'annotations-api', version: '6.0.53' // necessary for Java 9+
 


### PR DESCRIPTION
**Fix**: Resolve compatibility issue with gRPC 1.61.0

**Problem**: Upgrading to gRPC 1.61.0 triggered the following error:

```
Caused by: java.lang.IllegalStateException: Could not find policy 'pick_first'. Make sure its implementation is either registered to LoadBalancerRegistry or included in META-INF/services/io.grpc.LoadBalancerProvider from your jar files.
```

**Solution**: Added the `grpc-util` dependency to address the issue. This ensures the correct registration of the 'pick_first' load balancing policy.