### PR TITLE
Fix Fat Jar Assembly Issue

### DIFF
--- a/java-spiffe-helper/build.gradle
+++ b/java-spiffe-helper/build.gradle
@@ -9,6 +9,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 assemble.dependsOn shadowJar
 
 shadowJar {
+    mergeServiceFiles()
     archiveClassifier = osdetector.classifier
     manifest {
         attributes 'Main-Class': 'io.spiffe.helper.cli.Runner'

--- a/java-spiffe-provider/build.gradle
+++ b/java-spiffe-provider/build.gradle
@@ -10,6 +10,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 assemble.dependsOn shadowJar
 
 shadowJar {
+    mergeServiceFiles()
     archiveClassifier = "all-".concat(osdetector.classifier)
 }
 


### PR DESCRIPTION
This PR updates the shadowJar configuration by adding `mergeServiceFiles()`. This adjustment ensures SPI files are properly merged in fat jars, avoiding overwrites and enabling the Service Loader to function correctly. This fix is essential for addressing the `java.lang.IllegalStateException: Could not find policy 'pick_first'` error, ensuring the necessary implementations are registered in the LoadBalancerRegistry and included in `META-INF/services/io.grpc.LoadBalancerProvider`.