### PR TITLE
Fix JacocoTestReport Config

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Generate and upload coverage report
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew build jacocoTestReport coveralls
+        run: ./gradlew jacocoTestReport coveralls
       - name: Cleanup Gradle Cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
         # Restoring these files from a GitHub Actions cache might cause problems for future builds.

--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,8 @@ subprojects {
                 }
             }
         }
+
+        finalizedBy jacocoTestReport
     }
 }
 
@@ -153,17 +155,17 @@ task jacocoTestReport(type: JacocoReport) {
     }
 }
 
+jacocoTestReport.dependsOn {
+    subprojects.collectMany { project ->
+        project.tasks.matching { it.name in ['test'] }
+    }
+}
+
 coveralls {
     jacocoReportPath 'build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml'
     sourceDirs = ['java-spiffe-core/src/main/java',
                   'java-spiffe-helper/src/main/java',
                   'java-spiffe-provider/src/main/java']
-}
-
-// always run the tests before generating the report
-jacocoTestReport.dependsOn {
-    subprojects*.test
-    copyJars // workaround to prevent deleting the build folder before generating the reports
 }
 
 // copy submodules jars to a common folder for deploy


### PR DESCRIPTION
**Issue:**
When generating the JacocoTestReport, an error occurred due to an implicit dependency issue between tasks.

```
What went wrong:
Some problems were found with the configuration of task ':jacocoTestReport' (type 'JacocoReport').
  - Gradle detected a problem with the following location: '/home/runner/work/java-spiffe/java-spiffe/java-spiffe-core/build/generated/source/proto/main/java'.
    
    Reason: Task ':jacocoTestReport' uses this output of task ':java-spiffe-core:generateProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

**Solution:**
Resolved the issue by specifying the correct dependency on the test task, ensuring proper task execution order and avoiding errors during JacocoTestReport generation.