### PR TITLE
Use Gradle Wrapper in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /builder
 RUN ./gradlew dependencies
 RUN ./gradlew java-spiffe-helper:assemble -ParchiveClassifier=docker -Pversion=docker
 
-FROM eclipse-temurin:17-jre  AS runner
+FROM eclipse-temurin:17-jre AS runner
 USER nobody
 
 COPY conf/java-spiffe-helper.properties /app/java-spiffe-helper.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM gradle:8.5.0-jdk17 AS builder
-COPY --chown=gradle:gradle . /builder
+FROM eclipse-temurin:17-jdk AS builder
 WORKDIR /builder
-RUN gradle dependencies
-RUN gradle java-spiffe-helper:assemble -ParchiveClassifier=docker -Pversion=docker
+COPY . /builder
 
-FROM eclipse-temurin:17-jre AS runner
-COPY --chown=nobody:nobody \
-  conf/java-spiffe-helper.properties /app/java-spiffe-helper.properties
-COPY --from=builder \
-  --chown=nobody:nobody \
-  /builder/java-spiffe-helper/build/libs/java-spiffe-helper-docker-docker.jar /app/java-spiffe-helper.jar
+RUN ./gradlew dependencies
+RUN ./gradlew java-spiffe-helper:assemble -ParchiveClassifier=docker -Pversion=docker
+
+FROM eclipse-temurin:17-jre  AS runner
 USER nobody
+
+COPY conf/java-spiffe-helper.properties /app/java-spiffe-helper.properties
+COPY --from=builder /builder/java-spiffe-helper/build/libs/java-spiffe-helper-docker-docker.jar /app/java-spiffe-helper.jar
+
 ENTRYPOINT ["java", "-jar", "/app/java-spiffe-helper.jar"]
 CMD ["--config", "/app/java-spiffe-helper.properties"]


### PR DESCRIPTION
This PR updates the Dockerfile to utilize the Gradle Wrapper for building the `java-spiffe-helper` image. By leveraging the Gradle Wrapper, we ensure consistency in the Gradle version used for building the project.