### PR TITLE
Change CI macos jdk distribution to zulu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
**Context:** This PR addresses the issue detailed in [actions/setup-java#625](https://github.com/actions/setup-java/issues/625).

**Summary:**  
The `temurin` and `adopt` distributions no longer provide a JDK v8 distribution for macOS. As a result, we've switched to using the `zulu` distribution, which offers JDK v8 support for macOS.

**Changes:**  
- Updated the workflow to set up JDK v8 using the `zulu` distribution.

**Testing:**  
- Verified that the JDK v8 setup on macOS now works as expected with the `zulu` distribution.