### PR TITLE
Bump `com.google.protobuf:protoc` to `3.25.5`

### DIFF
--- a/java-spiffe-core/build.gradle
+++ b/java-spiffe-core/build.gradle
@@ -50,7 +50,7 @@ task integrationTest(type: Test) {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.25.3'
+        artifact = 'com.google.protobuf:protoc:3.25.5'
     }
     plugins {
         grpc {


### PR DESCRIPTION
Due to unresolved errors when compiling gRPC protobuf code with protoc 4.x, updating to the latest 3.x.x version, `3.21.5`.

Reference: See [grpc-java issue #11015](https://github.com/grpc/grpc-java/issues/11015) for details.