### PR TITLE
Fix CRLF newline removal in DER format logic

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/internal/CertificateUtils.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/internal/CertificateUtils.java
@@ -229,8 +229,8 @@ public class CertificateUtils {
     // Given a private key in PEM format, encode it as DER
     private static byte[] toDerFormat(final byte[] privateKeyPem) throws InvalidKeyException {
         String privateKeyAsString = new String(privateKeyPem);
-        privateKeyAsString = privateKeyAsString.replaceAll("(-+BEGIN PRIVATE KEY-+\\r?\\n|-+END PRIVATE KEY-+\\r?\\n?)", "");
-        privateKeyAsString = privateKeyAsString.replaceAll("\n", "");
+        privateKeyAsString = privateKeyAsString.replaceAll("(-+BEGIN PRIVATE KEY-+|-+END PRIVATE KEY-+)", "");
+        privateKeyAsString = privateKeyAsString.replaceAll("\r?\n", "");
         val decoder = Base64.getDecoder();
         try {
             return decoder.decode(privateKeyAsString);


### PR DESCRIPTION
[In our repo](https://github.com/SAP/cloud-sdk-java/) we found Windows users unable to run certain tests, that require SPIFFE to load a local PEM file.
On Windows (some?) local Git installations default to Windows line-endings during checkout: `CRLF` (`\r\n`)  instead of `LF` (`\n`).

Unfortunately `CertificateUtils` does not _correctly_ consider that case.
This is a suggestion to make it right, and simplify the code a bit.