### PR TITLE
sslNegotiation is needed to pickup SpiffeSslSocketFactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ subprojects {
 
     ext {
         grpcVersion = '1.72.0'
-        jupiterVersion = '5.12.1'
+        jupiterVersion = '5.12.2'
         mockitoVersion = '4.11.0'
         lombokVersion = '1.18.38'
         nimbusVersion = '10.3'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ subprojects {
         jupiterVersion = '5.12.1'
         mockitoVersion = '4.11.0'
         lombokVersion = '1.18.38'
-        nimbusVersion = '10.2'
+        nimbusVersion = '10.3'
         shadowVersion = '8.1.1'
 
         //IMPORTANT: This must be in sync with the shaded netty version in gRPC

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
         shadowVersion = '8.1.1'
 
         //IMPORTANT: This must be in sync with the shaded netty version in gRPC
-        nettyVersion = '4.2.0.Final'
+        nettyVersion = '4.2.1.Final'
     }
 
     apply plugin: 'java-library'

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ subprojects {
         testRuntimeOnly group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockitoVersion}"
 
         if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
-            testImplementation group: 'uk.org.webcompere', name: 'system-stubs-core', version: '2.1.8' // Last version supporting Java 8
+            testImplementation group: 'uk.org.webcompere', name: 'system-stubs-core', version: '2.0.3' // Last version supporting Java 8
         } else {
             testImplementation group: 'uk.org.webcompere', name: 'system-stubs-core', version: '2.1.8'
         }

--- a/java-spiffe-provider/README.md
+++ b/java-spiffe-provider/README.md
@@ -147,11 +147,12 @@ from a SPIRE Agent, keep them updated in memory, and provide them for TLS connec
 The URL to connect to Postgres using TLS and Java SPIFFE is as follows:
 
 ```
-jdbc:postgresql://localhost:5432/postgres?sslmode=require&sslfactory=io.spiffe.provider.SpiffeSslSocketFactory
+jdbc:postgresql://localhost:5432/postgres?sslmode=require&sslfactory=io.spiffe.provider.SpiffeSslSocketFactory&sslNegotiation=direct
 ```
 
 The parameter `sslfactory` in the URL configures the Postgres JDBC driver to use the `SpiffeSslSocketFactory` which wraps 
-around an SSL Socket with the Java SPIFFE functionality.
+around an SSL Socket with the Java SPIFFE functionality. Additional parameter `sslNegotiation` is needed to instantiate
+`SpiffeSslSocketFactory` correct.
 
 The Workload API socket endpoint should be configured through the Environment variable `SPIFFE_ENDPOINT_SOCKET`.
 


### PR DESCRIPTION
SpiffeSslSocketFactory is only used correct with direct mode when using envoy-proxy in front of pg