### PR TITLE
Prepare release `v0.8.13`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.8.13] - 2025-07-15
+
+### Dependency updates
+
+* Bump io.netty:netty-transport-native-kqueue to 4.2.2.Final (#332)
+* Bump com.nimbusds:nimbus-jose-jwt to 10.3.1 (#335)
+* Bump commons-validator:commons-validator to 1.10.0 (#338)
+* Bump org.apache.commons:commons-lang3 to 3.18.0 (#339)
+
 ## [0.8.12] - 2025-06-05
 
 ### Dependency updates

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ X.509 and JWT SVIDs and bundles.
 Download
 --------
 
-The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.8.12). 
+The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.8.13). 
 
 The dependencies can be added to `pom.xml`
 
@@ -35,7 +35,7 @@ To import the `java-spiffe-provider` component:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-provider</artifactId>
-  <version>0.8.12</version>
+  <version>0.8.13</version>
 </dependency>
 ```
 The `java-spiffe-provider` component imports the `java-spiffe-core` component.
@@ -45,7 +45,7 @@ To just import the `java-spiffe-core` component:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-core</artifactId>
-  <version>0.8.12</version>
+  <version>0.8.13</version>
 </dependency>
 ```
 
@@ -53,12 +53,12 @@ Using Gradle:
 
 Import `java-spiffe-provider`:
 ```gradle
-implementation group: 'io.spiffe', name: 'java-spiffe-provider', version: '0.8.12'
+implementation group: 'io.spiffe', name: 'java-spiffe-provider', version: '0.8.13'
 ```
 
 Import `java-spiffe-core`:
 ```gradle
-implementation group: 'io.spiffe', name: 'java-spiffe-core', version: '0.8.12'
+implementation group: 'io.spiffe', name: 'java-spiffe-core', version: '0.8.13'
 ```
 
 ### MacOS Support
@@ -72,14 +72,14 @@ In case run on a osx-x86 architecture, add to your `pom.xml`:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>grpc-netty-macos</artifactId>
-  <version>0.8.12</version>
+  <version>0.8.13</version>
   <scope>runtime</scope>
 </dependency>
 ```
 
 Using Gradle:
 ```gradle
-runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos', version: '0.8.12'
+runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos', version: '0.8.13'
 ```
 
 #### Aarch64 (M1) Architecture
@@ -91,7 +91,7 @@ If you are running the aarch64 architecture (M1 CPUs), add to your `pom.xml`:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>grpc-netty-macos-aarch64</artifactId>
-  <version>0.8.12</version>
+  <version>0.8.13</version>
   <scope>runtime</scope>
 </dependency>
 ```
@@ -99,7 +99,7 @@ If you are running the aarch64 architecture (M1 CPUs), add to your `pom.xml`:
 Using Gradle:
 
 ```gradle
-runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos-aarch64', version: '0.8.12'
+runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos-aarch64', version: '0.8.13'
 ```
 
 *Caveat: not all OpenJDK distributions are aarch64 native, make sure your JDK is also running
@@ -112,7 +112,7 @@ The `java-spiffe-helper` module manages X.509 SVIDs and Bundles in Java Keystore
 
 ### Docker Image
 
-Pull the `java-spiffe-helper` image from `ghcr.io/spiffe/java-spiffe-helper:0.8.12`.
+Pull the `java-spiffe-helper` image from `ghcr.io/spiffe/java-spiffe-helper:0.8.13`.
 
 For more details, see [java-spiffe-helper/README.md](java-spiffe-helper/README.md).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.8.12
-mavenDeployUrl=https://oss.sonatype.org/service/local/staging/deploy/maven2
+version=0.8.13
+mavenDeployUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2"

--- a/java-spiffe-helper/README.md
+++ b/java-spiffe-helper/README.md
@@ -10,11 +10,11 @@ The Helper automatically gets the SVID updates and stores them in the KeyStore a
 
 On Linux:
 
-`java -jar java-spiffe-helper-0.8.12-linux-x86_64.jar`
+`java -jar java-spiffe-helper-0.8.13-linux-x86_64.jar`
 
 On Mac OS:
 
-`java -jar java-spiffe-helper-0.8.12-osx-x86_64.jar`
+`java -jar java-spiffe-helper-0.8.13-osx-x86_64.jar`
 
 You can run the utility with the `-c` or `--config` option to specify the path to the configuration file. By default, it
 will look for a configuration file named `conf/java-spiffe-helper.properties` in the current working directory.


### PR DESCRIPTION
Prepares the 0.8.13 release:

- Updates project dependencies to latest compatible versions
- Updates `mavenDeployUrl` to use Maven Central for artifact deployment.