### PR TITLE
ci: standardize on Temurin JDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v5
         with:
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v5
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Generate JaCoCo report
         run: ./gradlew test jacocoTestReport

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Publish to Maven Central
         run: ./gradlew publishToMavenCentral
 


### PR DESCRIPTION
This PR consolidates our GitHub Actions builds on Eclipse Temurin. 

Replaces `distribution: adopt` / `distribution: zulu` with `distribution: temurin`