### PR TITLE
Fix SPIFFE ID scheme detection

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/spiffeid/SpiffeId.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/spiffeid/SpiffeId.java
@@ -72,7 +72,7 @@ public final class SpiffeId {
             throw new IllegalArgumentException(EMPTY);
         }
 
-        if (!id.contains(SCHEME_PREFIX)) {
+        if (!id.startsWith(SCHEME_PREFIX)) {
             throw new InvalidSpiffeIdException(WRONG_SCHEME);
         }
 

--- a/java-spiffe-core/src/test/java/io/spiffe/spiffeid/SpiffeIdTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/spiffeid/SpiffeIdTest.java
@@ -98,7 +98,8 @@ class SpiffeIdTest {
                 Arguments.of("spiffe://trustdomain/./other", "Path cannot contain dot segments"),
                 Arguments.of("spiffe://trustdomain/../other", "Path cannot contain dot segments"),
                 Arguments.of("spiffe://trustdomain/", "Path cannot have a trailing slash"),
-                Arguments.of("spiffe://trustdomain/path/", "Path cannot have a trailing slash")
+                Arguments.of("spiffe://trustdomain/path/", "Path cannot have a trailing slash"),
+                Arguments.of("xspiffe://trustdomain/path", "Scheme is missing or invalid")
         );
     }
 


### PR DESCRIPTION
## Summary 

This PR fixes SPIFFE ID parsing to require the `spiffe://` scheme to appear at the beginning of the identifier rather than anywhere in the string. This aligns scheme validation with the SPIFFE specification and prevents malformed IDs from being accepted. A small regression test is included.
