### PR TITLE
fix(core): harden parsing and cache edge cases

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/bundle/jwtbundle/JwtBundleSet.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/bundle/jwtbundle/JwtBundleSet.java
@@ -39,6 +39,7 @@ public final class JwtBundleSet implements BundleSource<JwtBundle> {
         }
         final Map<TrustDomain, JwtBundle> bundleMap = new ConcurrentHashMap<>();
         for (JwtBundle bundle : bundles) {
+            Objects.requireNonNull(bundle, "bundle must not be null");
             bundleMap.put(bundle.getTrustDomain(), bundle);
         }
         return new JwtBundleSet(bundleMap);

--- a/java-spiffe-core/src/main/java/io/spiffe/bundle/x509bundle/X509BundleSet.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/bundle/x509bundle/X509BundleSet.java
@@ -40,6 +40,7 @@ public final class X509BundleSet implements BundleSource<X509Bundle> {
 
         final Map<TrustDomain, X509Bundle> bundleMap = new ConcurrentHashMap<>();
         for (X509Bundle bundle : bundles) {
+            Objects.requireNonNull(bundle, "bundle must not be null");
             bundleMap.put(bundle.getTrustDomain(), bundle);
         }
         return new X509BundleSet(bundleMap);

--- a/java-spiffe-core/src/main/java/io/spiffe/spiffeid/TrustDomain.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/spiffeid/TrustDomain.java
@@ -34,12 +34,11 @@ public final class TrustDomain {
             throw new IllegalArgumentException("Trust domain is missing");
         }
 
-        // Something looks kinda like a scheme separator, let's try to parse as
-        // an ID. We use :/ instead of :// since the diagnostics are better for
-        // a bad input like spiffe:/trustdomain.
+        // Heuristic: if the input resembles a SPIFFE ID or a URI scheme
+        // (e.g. spiffe://..., spiffe:/..., or <scheme>:/...), delegate parsing
+        // to SpiffeId.parse() so scheme-related errors are reported consistently.
         if (idOrName.contains(":/")) {
-            SpiffeId spiffeId = SpiffeId.parse(idOrName);
-            return spiffeId.getTrustDomain();
+            return SpiffeId.parse(idOrName).getTrustDomain();
         }
 
         validateTrustDomainName(idOrName);

--- a/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
@@ -393,6 +393,9 @@ public class JwtSvid {
 
     // expected audiences must be a subset of the audience claim in the token
     private static void validateAudience(List<String> audClaim, Set<String> expectedAudiences) throws JwtSvidException {
+        if (audClaim == null || audClaim.isEmpty()) {
+            throw new JwtSvidException("Token missing audience claim");
+        }
         if (!audClaim.containsAll(expectedAudiences)) {
             throw new JwtSvidException(String.format("expected audience in %s (audience=%s)", expectedAudiences, audClaim));
         }

--- a/java-spiffe-core/src/test/java/io/spiffe/bundle/jwtbundle/JwtBundleSetTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/bundle/jwtbundle/JwtBundleSetTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -152,5 +153,13 @@ class JwtBundleSetTest {
         } catch (NullPointerException e) {
             assertEquals("jwtBundle must not be null", e.getMessage());
         }
+    }
+
+    @Test
+    void testOf_nullElementInCollection_throwsNullPointerException() {
+        JwtBundle jwtBundle1 = new JwtBundle(TrustDomain.parse("example.org"));
+        List<JwtBundle> bundles = Arrays.asList(jwtBundle1, null);
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> JwtBundleSet.of(bundles));
+        assertEquals("bundle must not be null", exception.getMessage());
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/bundle/x509bundle/X509BundleSetTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/bundle/x509bundle/X509BundleSetTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -148,5 +149,13 @@ class X509BundleSetTest {
         } catch (NullPointerException e) {
             assertEquals("trustDomain must not be null", e.getMessage());
         }
+    }
+
+    @Test
+    void testOf_nullElementInCollection_throwsNullPointerException() {
+        X509Bundle x509Bundle1 = new X509Bundle(TrustDomain.parse("example.org"));
+        List<X509Bundle> bundles = Arrays.asList(x509Bundle1, null);
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> X509BundleSet.of(bundles));
+        assertEquals("bundle must not be null", exception.getMessage());
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/spiffeid/TrustDomainTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/spiffeid/TrustDomainTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 
 import static io.spiffe.spiffeid.SpiffeIdTest.TD_CHARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class TrustDomainTest {
@@ -103,5 +104,29 @@ class TrustDomainTest {
     void test_toIdString() {
         final TrustDomain trustDomain = TrustDomain.parse("domain.test");
         assertEquals("spiffe://domain.test", trustDomain.toIdString());
+    }
+
+    @Test
+    void testParseFromSpiffeIdWithPath_extractsTrustDomain() {
+        TrustDomain trustDomain = TrustDomain.parse("spiffe://example.org/foo");
+        assertEquals("example.org", trustDomain.getName());
+    }
+
+    @Test
+    void testParseInvalidScheme_spiffeWithSingleSlash_throwsInvalidScheme() {
+        assertThrows(InvalidSpiffeIdException.class,
+                () -> TrustDomain.parse("spiffe:/example.org"));
+    }
+
+    @Test
+    void testParseInvalidScheme_httpScheme_throwsInvalidScheme() {
+        assertThrows(InvalidSpiffeIdException.class,
+                () -> TrustDomain.parse("http://example.org"));
+    }
+
+    @Test
+    void testParseColonNotFollowedBySlash_validatesAsTrustDomain() {
+        assertThrows(InvalidSpiffeIdException.class,
+                () -> TrustDomain.parse("trustdomain:test"));
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
@@ -179,6 +179,22 @@ class JwtSvidParseAndValidateTest {
                                 TestUtils.generateToken(claims, key3, "authority3"),
                                 ""
                         ))
+                        .build()),
+                Arguments.of(TestCase.builder()
+                        .name("audience contains expected - success")
+                        .jwtBundle(jwtBundle)
+                        .expectedAudience(Collections.singleton("audience1"))
+                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1"))
+                        .expectedException(null)
+                        .expectedJwtSvid(newJwtSvidInstance(
+                                trustDomain.newSpiffeId("host"),
+                                audience,
+                                issuedAt,
+                                expiration,
+                                claims.getClaims(),
+                                TestUtils.generateToken(claims, key1, "authority1"),
+                                null
+                        ))
                         .build())
         );
     }
@@ -242,6 +258,27 @@ class JwtSvidParseAndValidateTest {
                         .expectedAudience(Collections.singleton("another"))
                         .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1"))
                         .expectedException(new JwtSvidException("expected audience in [another] (audience=[audience2, audience1])"))
+                        .build()),
+                Arguments.of(TestCase.builder()
+                        .name("missing audience claim")
+                        .jwtBundle(jwtBundle)
+                        .expectedAudience(audience)
+                        .generateToken(() -> TestUtils.generateToken(new JWTClaimsSet.Builder()
+                                .subject(spiffeId.toString())
+                                .expirationTime(expiration)
+                                .build(), key1, "authority1"))
+                        .expectedException(new JwtSvidException("Token missing audience claim"))
+                        .build()),
+                Arguments.of(TestCase.builder()
+                        .name("empty audience claim")
+                        .jwtBundle(jwtBundle)
+                        .expectedAudience(audience)
+                        .generateToken(() -> TestUtils.generateToken(new JWTClaimsSet.Builder()
+                                .subject(spiffeId.toString())
+                                .expirationTime(expiration)
+                                .audience(Collections.emptyList())
+                                .build(), key1, "authority1"))
+                        .expectedException(new JwtSvidException("Token missing audience claim"))
                         .build()),
                 Arguments.of(TestCase.builder()
                         .name("invalid subject claim")


### PR DESCRIPTION
## Summary

- Reject null elements when building bundle sets
- JwtSvid: fail fast when the aud claim is missing/empty
- CachedJwtSource: guard empty cache entries and reject empty Workload API results
- TrustDomain: add parsing edge-case coverage
- Add unit tests for all changes