### PR TITLE
chore(ci): improve dependabot config and group coupled gradle deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,36 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    directory: "/" 
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      grpc:
+        patterns:
+          - "io.grpc:*"
+          - "io.netty:*"
+
+      protobuf:
+        patterns:
+          - "com.google.protobuf:*"
+          - "io.grpc:protoc-gen-grpc-java"
+
+      test:
+        patterns:
+          - "org.junit.jupiter:*"
+          - "org.mockito:*"
+          - "uk.org.webcompere:*"
+          - "org.bouncycastle:*"
+
   - package-ecosystem: "github-actions"
-    directory: "/" 
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What
Update Dependabot configuration for the Java SPIFFE repo:

* Switch Gradle and GitHub Actions updates to weekly cadence
* Add Conventional Commit prefixes
* Group only tightly coupled dependency stacks:
  * gRPC / Netty
  * Protobuf toolchain
  * Test dependencies
* Leave all other dependencies ungrouped for isolated PRs

## Why

* Reduce PR noise while keeping risky dependencies independently reviewable
* Keep related libraries upgraded together to avoid version skew
