### PR TITLE
chore(release): prepare release 0.8.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.8.17] - 2026-04-20
+
+### Fixed
+
+* Enforce SPIFFE-spec-compliant URI SAN validation for X.509-SVID leaf certificates (#421)
+* Require a non-root SPIFFE ID path for X.509-SVID leaf certificates, per the SPIFFE spec (#417)
+* Tighten SPIFFE ID path validation and segment construction to match the SPIFFE spec (#420)
+* Parse SPIFFE IDs case-insensitively and normalize trust domains to lowercase in accordance with the SPIFFE spec (#416)
+
+### Dependency updates
+
+* Bump grpcVersion from 1.79.0 to 1.80.0 (#414)
+* Bump com.nimbusds:nimbus-jose-jwt from 10.8 to 10.9 (#423)
+* Bump gradle-wrapper from 9.3.1 to 9.4.1 (#412, #419)
+
+
 ## [0.8.16] - 2026-02-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ X.509 and JWT SVIDs and bundles.
 Download
 --------
 
-The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.8.16). 
+The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.8.17). 
 
 The dependencies can be added to `pom.xml`
 
@@ -35,7 +35,7 @@ To import the `java-spiffe-provider` component:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-provider</artifactId>
-  <version>0.8.16</version>
+  <version>0.8.17</version>
 </dependency>
 ```
 The `java-spiffe-provider` component imports the `java-spiffe-core` component.
@@ -45,7 +45,7 @@ To just import the `java-spiffe-core` component:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-core</artifactId>
-  <version>0.8.16</version>
+  <version>0.8.17</version>
 </dependency>
 ```
 
@@ -53,12 +53,12 @@ Using Gradle:
 
 Import `java-spiffe-provider`:
 ```gradle
-implementation group: 'io.spiffe', name: 'java-spiffe-provider', version: '0.8.16'
+implementation group: 'io.spiffe', name: 'java-spiffe-provider', version: '0.8.17'
 ```
 
 Import `java-spiffe-core`:
 ```gradle
-implementation group: 'io.spiffe', name: 'java-spiffe-core', version: '0.8.16'
+implementation group: 'io.spiffe', name: 'java-spiffe-core', version: '0.8.17'
 ```
 
 ### MacOS Support
@@ -72,14 +72,14 @@ In case run on a osx-x86 architecture, add to your `pom.xml`:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>grpc-netty-macos</artifactId>
-  <version>0.8.16</version>
+  <version>0.8.17</version>
   <scope>runtime</scope>
 </dependency>
 ```
 
 Using Gradle:
 ```gradle
-runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos', version: '0.8.16'
+runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos', version: '0.8.17'
 ```
 
 #### Aarch64 (M1) Architecture
@@ -91,7 +91,7 @@ If you are running the aarch64 architecture (M1 CPUs), add to your `pom.xml`:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>grpc-netty-macos-aarch64</artifactId>
-  <version>0.8.16</version>
+  <version>0.8.17</version>
   <scope>runtime</scope>
 </dependency>
 ```
@@ -99,7 +99,7 @@ If you are running the aarch64 architecture (M1 CPUs), add to your `pom.xml`:
 Using Gradle:
 
 ```gradle
-runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos-aarch64', version: '0.8.16'
+runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos-aarch64', version: '0.8.17'
 ```
 
 *Caveat: not all OpenJDK distributions are aarch64 native, make sure your JDK is also running
@@ -112,7 +112,7 @@ The `java-spiffe-helper` module manages X.509 SVIDs and Bundles in Java Keystore
 
 ### Docker Image
 
-Pull the `java-spiffe-helper` image from `ghcr.io/spiffe/java-spiffe-helper:0.8.16`.
+Pull the `java-spiffe-helper` image from `ghcr.io/spiffe/java-spiffe-helper:0.8.17`.
 
 For more details, see [java-spiffe-helper/README.md](java-spiffe-helper/README.md).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.8.16
+version=0.8.17

--- a/java-spiffe-helper/README.md
+++ b/java-spiffe-helper/README.md
@@ -10,11 +10,11 @@ The Helper automatically gets the SVID updates and stores them in the KeyStore a
 
 On Linux:
 
-`java -jar java-spiffe-helper-0.8.16-linux-x86_64.jar`
+`java -jar java-spiffe-helper-0.8.17-linux-x86_64.jar`
 
 On Mac OS:
 
-`java -jar java-spiffe-helper-0.8.16-osx-x86_64.jar`
+`java -jar java-spiffe-helper-0.8.17-osx-x86_64.jar`
 
 You can run the utility with the `-c` or `--config` option to specify the path to the configuration file. By default, it
 will look for a configuration file named `conf/java-spiffe-helper.properties` in the current working directory.


### PR DESCRIPTION
## Summary

Prepares the **0.8.17** release by bumping `gradle.properties` and adding a new entry to `CHANGELOG.md` .