### PR TITLE
fix(workloadapi): refresh cached JWT SVIDs without iat

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/CachedJwtSource.java
@@ -270,12 +270,17 @@ public class CachedJwtSource implements JwtSource {
     }
 
     private boolean isTokenPastHalfLifetime(JwtSvid jwtSvid) {
-        Instant now = clock.instant();
-        Date halfLife = new Date(jwtSvid.getExpiry().getTime() - (jwtSvid.getExpiry().getTime() - jwtSvid.getIssuedAt().getTime()) / 2);
-        Instant halfLifeInstant = Instant.ofEpochMilli(halfLife.getTime());
-        return now.isAfter(halfLifeInstant);
-    }
+        Object issuedAtClaim = jwtSvid.getClaims().get("iat");
+        if (!(issuedAtClaim instanceof Date)) {
+            return true;
+        }
 
+        long expiryTime = jwtSvid.getExpiry().getTime();
+        long issuedAtTime = ((Date) issuedAtClaim).getTime();
+        long halfLifeTime = expiryTime - (expiryTime - issuedAtTime) / 2;
+
+        return clock.instant().toEpochMilli() > halfLifeTime;
+    }
 
     private void init(final Duration timeout) throws TimeoutException {
         CountDownLatch done = new CountDownLatch(1);

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/CachedJwtSourceTest.java
@@ -1,6 +1,8 @@
 package io.spiffe.workloadapi;
 
 import com.google.common.collect.Sets;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jwt.JWTClaimsSet;
 import io.spiffe.bundle.jwtbundle.JwtBundle;
 import io.spiffe.exception.BundleNotFoundException;
 import io.spiffe.exception.JwtSourceException;
@@ -9,18 +11,21 @@ import io.spiffe.exception.SocketEndpointAddressException;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.spiffeid.TrustDomain;
 import io.spiffe.svid.jwtsvid.JwtSvid;
+import io.spiffe.utils.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 import java.io.IOException;
+import java.security.KeyPair;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -173,6 +178,24 @@ class CachedJwtSourceTest {
         } catch (JwtSvidException e) {
             fail(e);
         }
+    }
+
+   @Test
+    void testFetchJwtSvidWithSubject_cachedJwtSvidWithoutIssuedAt_refetchesWithoutThrowingNullPointerException() throws JwtSvidException {
+        Set<String> audience = Collections.singleton(TEST_AUDIENCE);
+        Date expiration = Date.from(clock.instant().plus(JWT_TTL));
+        JWTClaimsSet claims = TestUtils.buildJWTClaimSet(audience, TEST_SUBJECT.toString(), expiration);
+        KeyPair keyPair = TestUtils.generateECKeyPair(Curve.P_521);
+        JwtSvid svidWithoutIssuedAt = JwtSvid.parseInsecure(TestUtils.generateToken(claims, keyPair, "authority1"), audience);
+
+        jwtSource.putCachedJwtSvidsForTest(TEST_SUBJECT, audience, Collections.singletonList(svidWithoutIssuedAt));
+        int initialCallCount = workloadApiClient.getFetchJwtSvidCallCount();
+
+        JwtSvid svid = assertDoesNotThrow(() -> jwtSource.fetchJwtSvid(TEST_SUBJECT, TEST_AUDIENCE));
+
+        assertNotNull(svid);
+        assertEquals(TEST_SUBJECT, svid.getSpiffeId());
+        assertEquals(initialCallCount + 1, workloadApiClient.getFetchJwtSvidCallCount());
     }
 
     @Test


### PR DESCRIPTION
## What

Update `CachedJwtSource` so cached JWT SVIDs without an `iat` claim are treated as needing refresh instead of computing half-life from a missing issued-at value.

Add a regression test that seeds the cache with a JWT SVID containing `sub` and `exp` but no `iat`, then verifies the cache path does not throw `NullPointerException`.

## Why

`JwtSvid` parsing currently allows JWT SVIDs without `iat`, but `CachedJwtSource.isTokenPastHalfLifetime` assumed `getIssuedAt()` was always available. That could crash cache reuse with a `NullPointerException`.

The fix keeps JWT SVID validation behavior unchanged and makes only the cache behavior more conservative.

## How tested

Ran:

`./gradlew :java-spiffe-core:test --tests io.spiffe.workloadapi.CachedJwtSourceTest --tests io.spiffe.workloadapi.DefaultJwtSourceTest`