### PR TITLE
fix(jwt): reject empty JWT-SVID audiences

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/svid/jwtsvid/JwtSvid.java
@@ -103,7 +103,8 @@ public class JwtSvid {
      *                                    when the signature cannot be verified,
      *                                    when the 'aud' claim has an audience that is not in the audience list
      *                                    provided as parameter
-     * @throws IllegalArgumentException   when the token is blank or cannot be parsed
+     * @throws IllegalArgumentException   when the token is blank, when the audience is empty, or when the token
+     *                                    cannot be parsed
      * @throws BundleNotFoundException    if the bundle for the trust domain of the spiffe id from the 'sub'
      *                                    cannot be found in the JwtBundleSource
      * @throws AuthorityNotFoundException if the authority cannot be found in the bundle using the value from
@@ -111,11 +112,12 @@ public class JwtSvid {
      */
     public static JwtSvid parseAndValidate(String token,
                                            BundleSource<JwtBundle> jwtBundleSource,
-                                           Set<String> audience)
+                                           Set<String>   audience)
             throws JwtSvidException, BundleNotFoundException, AuthorityNotFoundException {
         Objects.requireNonNull(token, "token must not be null");
         Objects.requireNonNull(jwtBundleSource, "jwtBundleSource must not be null");
         Objects.requireNonNull(audience, "audience must not be null");
+        requireNonEmptyAudience(audience);
 
         return parseAndValidate(token, jwtBundleSource, audience, null);
     }
@@ -139,7 +141,8 @@ public class JwtSvid {
      *                                    when the signature cannot be verified,
      *                                    when the 'aud' claim has an audience that is not in the audience list
      *                                    provided as parameter
-     * @throws IllegalArgumentException   when the token is blank or cannot be parsed
+     * @throws IllegalArgumentException   when the token is blank, when the audience is empty, or when the token
+     *                                    cannot be parsed
      * @throws BundleNotFoundException    if the bundle for the trust domain of the spiffe id from the 'sub'
      *                                    cannot be found in the JwtBundleSource
      * @throws AuthorityNotFoundException if the authority cannot be found in the bundle using the value from
@@ -154,6 +157,7 @@ public class JwtSvid {
         Objects.requireNonNull(token, "token must not be null");
         Objects.requireNonNull(jwtBundleSource, "jwtBundleSource must not be null");
         Objects.requireNonNull(audience, "audience must not be null");
+        requireNonEmptyAudience(audience);
 
         if (StringUtils.isBlank(token)) {
             throw new IllegalArgumentException("token cannot be blank");
@@ -198,11 +202,12 @@ public class JwtSvid {
      *                                  when the 'aud' has an audience that is not in the audience provided as parameter,
      *                                  when the 'alg' is not supported (See {@link JwtSignatureAlgorithm}),
      *                                  when the header 'typ' is present and is not 'JWT' or 'JOSE'.
-     * @throws IllegalArgumentException when the token cannot be parsed
+     * @throws IllegalArgumentException when the audience is empty or when the token cannot be parsed
      */
     public static JwtSvid parseInsecure(String token, Set<String> audience) throws JwtSvidException {
         Objects.requireNonNull(token, "token must not be null");
         Objects.requireNonNull(audience, "audience must not be null");
+        requireNonEmptyAudience(audience);
         return parseInsecure(token, audience, null);
     }
 
@@ -220,11 +225,12 @@ public class JwtSvid {
      *                                  when the 'aud' has an audience that is not in the audience provided as parameter,
      *                                  when the 'alg' is not supported (See {@link JwtSignatureAlgorithm}),
      *                                  when the header 'typ' is present and is not 'JWT' or 'JOSE'.
-     * @throws IllegalArgumentException when the token cannot be parsed
+     * @throws IllegalArgumentException when the audience is empty or when the token cannot be parsed
      */
     public static JwtSvid parseInsecure(String token, Set<String> audience, final String hint) throws JwtSvidException {
         Objects.requireNonNull(token, "token must not be null");
         Objects.requireNonNull(audience, "audience must not be null");
+        requireNonEmptyAudience(audience);
         if (StringUtils.isBlank(token)) {
             throw new IllegalArgumentException("token cannot be blank");
         }
@@ -398,6 +404,12 @@ public class JwtSvid {
         }
         if (!audClaim.containsAll(expectedAudiences)) {
             throw new JwtSvidException(String.format("expected audience in %s (audience=%s)", expectedAudiences, audClaim));
+        }
+    }
+
+    private static void requireNonEmptyAudience(Set<String> audience) {
+        if (audience.isEmpty()) {
+            throw new IllegalArgumentException("audience cannot be empty");
         }
     }
 

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseAndValidateTest.java
@@ -260,6 +260,13 @@ class JwtSvidParseAndValidateTest {
                         .expectedException(new JwtSvidException("expected audience in [another] (audience=[audience2, audience1])"))
                         .build()),
                 Arguments.of(TestCase.builder()
+                        .name("empty expected audience")
+                        .jwtBundle(jwtBundle)
+                        .expectedAudience(Collections.emptySet())
+                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1"))
+                        .expectedException(new IllegalArgumentException("audience cannot be empty"))
+                        .build()),
+                Arguments.of(TestCase.builder()
                         .name("missing audience claim")
                         .jwtBundle(jwtBundle)
                         .expectedAudience(audience)

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/jwtsvid/JwtSvidParseInsecureTest.java
@@ -210,6 +210,12 @@ class JwtSvidParseInsecureTest {
                         .expectedException(new JwtSvidException("expected audience in [another] (audience=[audience])"))
                         .build()),
                 Arguments.of(TestCase.builder()
+                        .name("empty expected audience")
+                        .expectedAudience(Collections.emptySet())
+                        .generateToken(() -> TestUtils.generateToken(claims, key1, "authority1"))
+                        .expectedException(new IllegalArgumentException("audience cannot be empty"))
+                        .build()),
+                Arguments.of(TestCase.builder()
                         .name("invalid subject claim")
                         .expectedAudience(audience)
                         .generateToken(() -> TestUtils.generateToken(TestUtils.buildJWTClaimSet(audience, "non-spiffe-subject", expiration), key1, "authority1"))


### PR DESCRIPTION
## What

Reject empty expected audience sets in JWT-SVID validation for both `JwtSvid.parseAndValidate(...)` and `JwtSvid.parseInsecure(...)`.

## Why

Passing an empty expected audience set previously caused audience validation to succeed because `containsAll(emptySet())` is always true. This was a failure-open behavior in a security-sensitive validator.

This is an observable behavior change: empty expected audiences now throw `IllegalArgumentException("audience cannot be empty")`.

## How tested

Ran the focused JWT-SVID validation tests:

`./gradlew :java-spiffe-core:test --tests 'io.spiffe.svid.jwtsvid.JwtSvidParseAndValidateTest' --tests 'io.spiffe.svid.jwtsvid.JwtSvidParseInsecureTest'`