### PR TITLE
fix(retry): preserve sub-second retry delays

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/retry/RetryHandler.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/retry/RetryHandler.java
@@ -35,7 +35,7 @@ public class RetryHandler {
         if (exponentialBackoffPolicy.reachedMaxRetries(retryCount)) {
             return;
         }
-        executor.schedule(runnable, nextDelay.getSeconds(), TimeUnit.SECONDS);
+        executor.schedule(runnable, nextDelay.toMillis(), TimeUnit.MILLISECONDS);
         nextDelay = exponentialBackoffPolicy.nextDelay(nextDelay);
         retryCount++;
     }

--- a/java-spiffe-core/src/main/java/io/spiffe/workloadapi/retry/RetryHandler.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/workloadapi/retry/RetryHandler.java
@@ -39,7 +39,7 @@ public class RetryHandler {
         }
 
         try {
-            executor.schedule(runnable, nextDelay.getSeconds(), TimeUnit.SECONDS);
+            executor.schedule(runnable, nextDelay.toMillis(), TimeUnit.MILLISECONDS);
         } catch (RejectedExecutionException e) {
             return false;
         }

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/retry/RetryHandlerTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/retry/RetryHandlerTest.java
@@ -32,23 +32,38 @@ class RetryHandlerTest {
 
         retryHandler.scheduleRetry(runnable);
 
-        verify(scheduledExecutorService).schedule(runnable, 1, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 1000, TimeUnit.MILLISECONDS);
         assertEquals(1, retryHandler.getRetryCount());
 
         // second retry
         retryHandler.scheduleRetry(runnable);
         assertEquals(2, retryHandler.getRetryCount());
-        verify(scheduledExecutorService).schedule(runnable, 2, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 2000, TimeUnit.MILLISECONDS);
 
         // third retry
         retryHandler.scheduleRetry(runnable);
         assertEquals(3, retryHandler.getRetryCount());
-        verify(scheduledExecutorService).schedule(runnable, 4, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 4000, TimeUnit.MILLISECONDS);
 
         // fourth retry
         retryHandler.scheduleRetry(runnable);
         assertEquals(4, retryHandler.getRetryCount());
-        verify(scheduledExecutorService).schedule(runnable, 8, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 8000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void testScheduleRetry_subSecondDelay_usesMilliseconds() {
+        Runnable runnable = () -> { };
+        ExponentialBackoffPolicy exponentialBackoffPolicy = ExponentialBackoffPolicy.builder()
+                .initialDelay(Duration.ofMillis(250))
+                .build();
+
+        RetryHandler retryHandler = new RetryHandler(exponentialBackoffPolicy, scheduledExecutorService);
+
+        retryHandler.scheduleRetry(runnable);
+
+        verify(scheduledExecutorService).schedule(runnable, 250, TimeUnit.MILLISECONDS);
+        assertEquals(1, retryHandler.getRetryCount());
     }
 
     @Test
@@ -60,18 +75,18 @@ class RetryHandlerTest {
 
         retryHandler.scheduleRetry(runnable);
 
-        verify(scheduledExecutorService).schedule(runnable, 1, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 1000, TimeUnit.MILLISECONDS);
         assertEquals(1, retryHandler.getRetryCount());
 
         // second retry
         retryHandler.scheduleRetry(runnable);
         assertEquals(2, retryHandler.getRetryCount());
-        verify(scheduledExecutorService).schedule(runnable, 2, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 2000, TimeUnit.MILLISECONDS);
 
         // third retry
         retryHandler.scheduleRetry(runnable);
         assertEquals(3, retryHandler.getRetryCount());
-        verify(scheduledExecutorService).schedule(runnable, 4, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 4000, TimeUnit.MILLISECONDS);
 
         Mockito.reset(scheduledExecutorService);
 

--- a/java-spiffe-core/src/test/java/io/spiffe/workloadapi/retry/RetryHandlerTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/workloadapi/retry/RetryHandlerTest.java
@@ -42,23 +42,38 @@ class RetryHandlerTest {
 
         assertTrue(retryHandler.scheduleRetry(runnable));
 
-        verify(scheduledExecutorService).schedule(runnable, 1, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 1000, TimeUnit.MILLISECONDS);
         assertEquals(1, retryHandler.getRetryCount());
 
         // second retry
         assertTrue(retryHandler.scheduleRetry(runnable));
         assertEquals(2, retryHandler.getRetryCount());
-        verify(scheduledExecutorService).schedule(runnable, 2, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 2000, TimeUnit.MILLISECONDS);
 
         // third retry
         assertTrue(retryHandler.scheduleRetry(runnable));
         assertEquals(3, retryHandler.getRetryCount());
-        verify(scheduledExecutorService).schedule(runnable, 4, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 4000, TimeUnit.MILLISECONDS);
 
         // fourth retry
         assertTrue(retryHandler.scheduleRetry(runnable));
         assertEquals(4, retryHandler.getRetryCount());
-        verify(scheduledExecutorService).schedule(runnable, 8, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 8000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void testScheduleRetry_subSecondDelay_usesMilliseconds() {
+        Runnable runnable = () -> { };
+        ExponentialBackoffPolicy exponentialBackoffPolicy = ExponentialBackoffPolicy.builder()
+                .initialDelay(Duration.ofMillis(250))
+                .build();
+
+        RetryHandler retryHandler = new RetryHandler(exponentialBackoffPolicy, scheduledExecutorService);
+
+        retryHandler.scheduleRetry(runnable);
+
+        verify(scheduledExecutorService).schedule(runnable, 250, TimeUnit.MILLISECONDS);
+        assertEquals(1, retryHandler.getRetryCount());
     }
 
     @Test
@@ -70,18 +85,18 @@ class RetryHandlerTest {
 
         assertTrue(retryHandler.scheduleRetry(runnable));
 
-        verify(scheduledExecutorService).schedule(runnable, 1, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 1000, TimeUnit.MILLISECONDS);
         assertEquals(1, retryHandler.getRetryCount());
 
         // second retry
         assertTrue(retryHandler.scheduleRetry(runnable));
         assertEquals(2, retryHandler.getRetryCount());
-        verify(scheduledExecutorService).schedule(runnable, 2, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 2000, TimeUnit.MILLISECONDS);
 
         // third retry
         assertTrue(retryHandler.scheduleRetry(runnable));
         assertEquals(3, retryHandler.getRetryCount());
-        verify(scheduledExecutorService).schedule(runnable, 4, TimeUnit.SECONDS);
+        verify(scheduledExecutorService).schedule(runnable, 4000, TimeUnit.MILLISECONDS);
 
         Mockito.reset(scheduledExecutorService);
 


### PR DESCRIPTION
## What
- Schedule retry delays using millisecond precision instead of whole seconds.
- Add deterministic coverage for a sub-second retry delay.

## Why
`RetryHandler.scheduleRetry` used `Duration.getSeconds()`, which truncated delays below one second to zero and caused immediate retries.

## How tested
- `./gradlew :java-spiffe-core:test --tests io.spiffe.workloadapi.retry.RetryHandlerTest`
- `./gradlew :java-spiffe-core:test --tests 'io.spiffe.workloadapi.retry.*' --tests 'io.spiffe.workloadapi.DefaultWorkloadApiClientRetryableErrorTest'`