### PR TITLE
fix(core): harden SPIFFE URI SAN parsing

### DIFF
--- a/java-spiffe-core/src/main/java/io/spiffe/internal/CertificateUtils.java
+++ b/java-spiffe-core/src/main/java/io/spiffe/internal/CertificateUtils.java
@@ -1,5 +1,6 @@
 package io.spiffe.internal;
 
+import io.spiffe.exception.InvalidSpiffeIdException;
 import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.spiffeid.TrustDomain;
 
@@ -24,7 +25,6 @@ import static io.spiffe.internal.AsymmetricKeyAlgorithm.RSA;
 import static io.spiffe.internal.KeyUsage.CRL_SIGN;
 import static io.spiffe.internal.KeyUsage.DIGITAL_SIGNATURE;
 import static io.spiffe.internal.KeyUsage.KEY_CERT_SIGN;
-import static org.apache.commons.lang3.StringUtils.startsWith;
 
 /**
  * Common certificate utility methods.
@@ -32,7 +32,9 @@ import static org.apache.commons.lang3.StringUtils.startsWith;
 public class CertificateUtils {
 
     private static final String SPIFFE_PREFIX = "spiffe://";
+    private static final int SAN_TYPE_INDEX = 0;
     private static final int SAN_VALUE_INDEX = 1;
+    private static final int URI_SAN_TYPE = 6;
     private static final String PUBLIC_KEY_INFRASTRUCTURE_ALGORITHM = "PKIX";
     private static final String X509_CERTIFICATE_TYPE = "X.509";
 
@@ -122,7 +124,11 @@ public class CertificateUtils {
             throw new CertificateException("Certificate does not contain SPIFFE ID in the URI SAN");
         }
 
-        return SpiffeId.parse(spiffeIds.get(0));
+        try {
+            return SpiffeId.parse(spiffeIds.get(0));
+        } catch (InvalidSpiffeIdException | IllegalArgumentException e) {
+            throw new CertificateException("Certificate contains invalid SPIFFE ID in the URI SAN", e);
+        }
     }
 
     /**
@@ -182,8 +188,9 @@ public class CertificateUtils {
         }
         return certificate.getSubjectAlternativeNames()
                 .stream()
+                .filter(san -> URI_SAN_TYPE == (Integer) san.get(SAN_TYPE_INDEX))
                 .map(san -> (String) san.get(SAN_VALUE_INDEX))
-                .filter(uri -> startsWith(uri, SPIFFE_PREFIX))
+                .filter(uri -> uri != null && uri.startsWith(SPIFFE_PREFIX))
                 .collect(Collectors.toList());
     }
 

--- a/java-spiffe-core/src/test/java/io/spiffe/internal/CertificateUtilsTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/internal/CertificateUtilsTest.java
@@ -22,6 +22,7 @@ import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,6 +34,8 @@ import static io.spiffe.utils.X509CertificateTestUtils.createRootCA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class CertificateUtilsTest {
@@ -171,6 +174,43 @@ public class CertificateUtilsTest {
     }
 
     @Test
+    void testGetSpiffeId_certWithDnsAndIpSans_doesNotThrowClassCastException() throws Exception {
+        X509Certificate certificate = new CertificateWithSubjectAlternativeNames(Arrays.asList(
+                Arrays.asList(6, "spiffe://domain.test/workload"),
+                Arrays.asList(2, "workload.domain.test"),
+                Arrays.asList(7, "127.0.0.1")
+        ));
+
+        SpiffeId spiffeId = CertificateUtils.getSpiffeId(certificate);
+
+        assertEquals(SpiffeId.parse("spiffe://domain.test/workload"), spiffeId);
+    }
+
+    @Test
+    void testGetSpiffeId_certWithNonStringSanType_doesNotThrowClassCastException() throws Exception {
+        X509Certificate certificate = new CertificateWithSubjectAlternativeNames(Arrays.asList(
+                Arrays.asList(6, "spiffe://domain.test/workload"),
+                Arrays.asList(0, new byte[]{1, 2, 3})
+        ));
+
+        SpiffeId spiffeId = CertificateUtils.getSpiffeId(certificate);
+
+        assertEquals(SpiffeId.parse("spiffe://domain.test/workload"), spiffeId);
+    }
+
+    @Test
+    void testGetSpiffeId_certWithMalformedSpiffeUriSan_throwsCertificateException() throws Exception {
+        X509Certificate certificate = new CertificateWithSubjectAlternativeNames(Collections.singletonList(
+                Arrays.asList(6, "spiffe://domain.test/workload/invalid path")
+        ));
+
+        CertificateException exception = assertThrows(CertificateException.class, () -> CertificateUtils.getSpiffeId(certificate));
+
+        assertEquals("Certificate contains invalid SPIFFE ID in the URI SAN", exception.getMessage());
+        assertInstanceOf(RuntimeException.class, exception.getCause());
+    }
+
+    @Test
     void testGetSpiffeId_certNotContainSpiffeId_throwsCertificateException() throws Exception {
         final CertAndKeyPair rootCa = createRootCA("C = US, O = SPIFFE", "spiffe://domain.test");
         final CertAndKeyPair leaf = createCertificate("C = US, O = SPIRE", "C = US, O = SPIRE", "", rootCa, false);
@@ -214,5 +254,18 @@ public class CertificateUtilsTest {
         assertFalse(CertificateUtils.hasKeyUsageDigitalSignature(certificate));
         assertFalse(CertificateUtils.hasKeyUsageCertSign(certificate));
         assertFalse(CertificateUtils.hasKeyUsageCRLSign(certificate));
+    }
+
+    private static class CertificateWithSubjectAlternativeNames extends DummyX509Certificate {
+        private final Collection<List<?>> subjectAlternativeNames;
+
+        private CertificateWithSubjectAlternativeNames(Collection<List<?>> subjectAlternativeNames) {
+            this.subjectAlternativeNames = subjectAlternativeNames;
+        }
+
+        @Override
+        public Collection<List<?>> getSubjectAlternativeNames() throws CertificateParsingException {
+            return subjectAlternativeNames;
+        }
     }
 }

--- a/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidTest.java
+++ b/java-spiffe-core/src/test/java/io/spiffe/svid/x509svid/X509SvidTest.java
@@ -16,6 +16,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -25,6 +26,7 @@ import static io.spiffe.utils.X509CertificateTestUtils.createCertificate;
 import static io.spiffe.utils.X509CertificateTestUtils.createCertificateWithUriSans;
 import static io.spiffe.utils.X509CertificateTestUtils.createRootCA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -346,12 +348,15 @@ class X509SvidTest {
         byte[] certBytes = leaf.getCertificate().getEncoded();
         byte[] keyBytes = leaf.getKeyPair().getPrivate().getEncoded();
 
-        InvalidSpiffeIdException exception = assertThrows(
-                InvalidSpiffeIdException.class,
+        X509SvidException exception = assertThrows(
+                X509SvidException.class,
                 () -> X509Svid.parseRaw(certBytes, keyBytes)
         );
 
-        assertEquals("Path cannot have a trailing slash", exception.getMessage());
+        assertEquals("Certificate contains invalid SPIFFE ID in the URI SAN", exception.getMessage());
+        assertInstanceOf(CertificateException.class, exception.getCause());
+        assertInstanceOf(InvalidSpiffeIdException.class, exception.getCause().getCause());
+        assertEquals("Path cannot have a trailing slash", exception.getCause().getCause().getMessage());
     }
 
    @Test


### PR DESCRIPTION
## What

Harden `CertificateUtils` SPIFFE ID extraction by filtering Subject Alternative Name entries to URI SANs before casting SAN values, and wrap SPIFFE ID parse failures in `CertificateException`.

## Why

Non-URI SAN values can use non-string value types, which could previously cause `ClassCastException` before the SAN type was checked. Malformed SPIFFE URI SANs could also let unchecked parsing exceptions escape trust validation paths.

## How tested

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Not applicable

Ran:

`./gradlew :java-spiffe-core:test --tests io.spiffe.internal.CertificateUtilsTest`