### PR TITLE
fix(provider): validate peer chain before invoking SpiffeIdVerifier

### DIFF
--- a/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeTrustManager.java
+++ b/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeTrustManager.java
@@ -162,19 +162,19 @@ public final class SpiffeTrustManager extends X509ExtendedTrustManager {
         checkServerTrusted(chain, authType);
     }
 
-    // Check that the SPIFFE ID in the peer's certificate is accepted and the chain can be validated with a
-    // root CA in the bundle source
+    // Check that the peer's certificate chain can be validated with a root CA in the bundle source
+    // and that the SPIFFE ID in the peer's certificate is accepted.
     private void validatePeerChain(final X509Certificate... chain) throws CertificateException {
+        try {
+            X509SvidValidator.verifyChain(Arrays.asList(chain), x509BundleSource);
+        } catch (BundleNotFoundException e) {
+            throw new CertificateException(e.getMessage(), e);
+        }
+
         SpiffeId spiffeId = CertificateUtils.getSpiffeId(chain[0]);
         try {
             spiffeIdVerifier.verify(spiffeId, chain);
         } catch (SpiffeVerificationException e) {
-            throw new CertificateException(e.getMessage(), e);
-        }
-
-        try {
-            X509SvidValidator.verifyChain(Arrays.asList(chain), x509BundleSource);
-        } catch (BundleNotFoundException e) {
             throw new CertificateException(e.getMessage(), e);
         }
     }

--- a/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeTrustManagerTest.java
+++ b/java-spiffe-provider/src/test/java/io/spiffe/provider/SpiffeTrustManagerTest.java
@@ -33,6 +33,7 @@ import static io.spiffe.utils.X509CertificateTestUtils.createCertificateWithUriS
 import static io.spiffe.utils.X509CertificateTestUtils.createCertificateWithoutKeyUsage;
 import static io.spiffe.utils.X509CertificateTestUtils.createRootCA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
@@ -430,6 +431,22 @@ public class SpiffeTrustManagerTest {
         } catch (CertificateException e) {
             assertEquals("Stub failure.", e.getMessage());
         }
+    }
+
+    @Test
+    void checkServerTrusted_untrustedChain_verifierNotInvoked() throws BundleNotFoundException {
+        when(bundleSource.getBundleForTrustDomain(TrustDomain.parse("example.org"))).thenReturn(bundleUnknown);
+        final AtomicBoolean verifierInvoked = new AtomicBoolean(false);
+        final SpiffeIdVerifier verifier = (spiffeId, verifiedChain) -> verifierInvoked.set(true);
+
+        SpiffeTrustManager spiffeTrustManager = new SpiffeTrustManager(bundleSource, verifier);
+        try {
+            spiffeTrustManager.checkServerTrusted(chain, "");
+            fail("CertificateException was expected");
+        } catch (CertificateException e) {
+            assertEquals("Cert chain cannot be verified", e.getMessage());
+        }
+        assertFalse(verifierInvoked.get(), "verifier must not be invoked when the chain cannot be verified");
     }
 
     @Test


### PR DESCRIPTION
`SpiffeTrustManager` invoked the `SpiffeIdVerifier` before any cryptographic validation.
The callback received an unvalidated, attacker-supplied chain despite the verifier's [API spec calling it `verifiedChain`](https://github.com/spiffe/java-spiffe/blob/55200fc8e6b01f9da5951c379e4f4187d7f920b7/java-spiffe-provider/src/main/java/io/spiffe/provider/SpiffeIdVerifier.java#L13).

Validate the chain against the trust bundle first and only then invoke the verifier.

This matches go-spiffe, where [the `Authorizer` only receives chains returned by `x509svid.ParseAndVerify`](https://github.com/spiffe/go-spiffe/blob/v2.8.1/spiffetls/tlsconfig/config.go#L193-L201) (`ParseAndVerify` first checks the certificates, afterwards `Authorizer` checks if the SPIFFE ID is authorized).

Observable change: for a chain that is both untrusted and carries an unacceptable SPIFFE ID, the reported error is now the chain validation failure, rather than the verifier error.