### PR TITLE
ci(helper): refresh helper CI workflow

### DIFF
--- a/.github/workflows/java-spiffe-helper-ci.yaml
+++ b/.github/workflows/java-spiffe-helper-ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         spire-chart-version:
-          - spire: '0.28.x'
+          - spire: '0.29.x'
             crds: '0.5.x'
 
     env:

--- a/.github/workflows/java-spiffe-helper-ci.yaml
+++ b/.github/workflows/java-spiffe-helper-ci.yaml
@@ -2,6 +2,7 @@ name: Java SPIFFE Helper CI
 
 on:
   - pull_request
+  - workflow_dispatch
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
Update helper CI to use the SPIRE Helm chart `0.29.x` and allow the workflow to be run manually.
