### PR TITLE
ci(tests): update integration SPIRE to 1.15.2

### DIFF
--- a/.github/workflows/scripts/integration-tests.sh
+++ b/.github/workflows/scripts/integration-tests.sh
@@ -7,7 +7,7 @@ set -euf -o pipefail
 
 export SPIFFE_ENDPOINT_SOCKET="unix:/tmp/spire-agent/public/api.sock"
 
-spire_version="1.11.0"
+spire_version="1.15.2"
 spire_folder="spire-${spire_version}"
 spire_server_log_file="/tmp/spire-server/server.log"
 spire_agent_log_file="/tmp/spire-agent/agent.log"


### PR DESCRIPTION
## Summary
Update the SPIRE release used by the Workload API integration test script from `1.11.0` to `1.15.2`.

Keeps integration test coverage aligned with the latest SPIRE release.
