### PR TITLE
chore(release): prepare release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.9.0] - 2026-08-11
+
+### Breaking changes
+
+* `RetryHandler.scheduleRetry(Runnable)` now returns `boolean` instead of `void` to indicate whether a retry was scheduled.
+  This is source-compatible but binary-incompatible, so existing 0.8.x-compiled artifacts must be rebuilt (#436)
+
+### Changed
+
+* Registering a watch on a closed `WorkloadApiClient` now throws `IllegalStateException` instead of being accepted (#435)
+* X.509-SVID and JWT-SVID validation is stricter and rejects material that earlier versions accepted. See the
+  fixes below for details
+
+### Fixed
+
+* Validate the peer certificate chain against the trust bundle before invoking `SpiffeIdVerifier` (#449)
+* Enforce the X.509-SVID leaf profile when validating SVID certificates (#433)
+* Harden SPIFFE URI SAN parsing when extracting SPIFFE IDs from certificates (#434)
+* Reject empty JWT-SVID audience values (#431)
+* Publish JWT bundle updates safely to avoid torn reads (#429)
+* Refresh cached JWT-SVIDs that do not carry an `iat` claim (#430)
+* Reject new watches after the Workload API client is closed (#435)
+* Notify watchers when retries stop instead of failing silently (#436)
+* Preserve sub-second retry delays in the retry handler (#432)
+* Preserve multiple X.509 bundle authorities in the helper KeyStore (#428)
+
+### Dependency updates
+
+* Bump grpcVersion from 1.80.0 to 1.83.1 (#427, #440, #442, #446, #453)
+* Bump com.nimbusds:nimbus-jose-jwt from 10.9 to 10.9.1 (#438)
+* Bump commons-validator:commons-validator from 1.10.1 to 1.11.0 (#455)
+* Bump com.google.protobuf from 0.9.6 to 0.10.0 (#425)
+* Bump com.vanniktech.maven.publish from 0.35.0 to 0.37.0 (#445)
+* Bump gradle-wrapper from 9.4.1 to 9.6.1 (#426, #437, #443)
+* Bump the github-actions group with 2 updates (#441)
+
+
 ## [0.8.17] - 2026-04-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ X.509 and JWT SVIDs and bundles.
 Download
 --------
 
-The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.8.17). 
+The JARs can be downloaded from [Maven Central](https://search.maven.org/search?q=g:io.spiffe%20AND%20v:0.9.0). 
 
 The dependencies can be added to `pom.xml`
 
@@ -35,7 +35,7 @@ To import the `java-spiffe-provider` component:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-provider</artifactId>
-  <version>0.8.17</version>
+  <version>0.9.0</version>
 </dependency>
 ```
 The `java-spiffe-provider` component imports the `java-spiffe-core` component.
@@ -45,7 +45,7 @@ To just import the `java-spiffe-core` component:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>java-spiffe-core</artifactId>
-  <version>0.8.17</version>
+  <version>0.9.0</version>
 </dependency>
 ```
 
@@ -53,12 +53,12 @@ Using Gradle:
 
 Import `java-spiffe-provider`:
 ```gradle
-implementation group: 'io.spiffe', name: 'java-spiffe-provider', version: '0.8.17'
+implementation group: 'io.spiffe', name: 'java-spiffe-provider', version: '0.9.0'
 ```
 
 Import `java-spiffe-core`:
 ```gradle
-implementation group: 'io.spiffe', name: 'java-spiffe-core', version: '0.8.17'
+implementation group: 'io.spiffe', name: 'java-spiffe-core', version: '0.9.0'
 ```
 
 ### MacOS Support
@@ -72,14 +72,14 @@ In case run on a osx-x86 architecture, add to your `pom.xml`:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>grpc-netty-macos</artifactId>
-  <version>0.8.17</version>
+  <version>0.9.0</version>
   <scope>runtime</scope>
 </dependency>
 ```
 
 Using Gradle:
 ```gradle
-runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos', version: '0.8.17'
+runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos', version: '0.9.0'
 ```
 
 #### Aarch64 (M1) Architecture
@@ -91,7 +91,7 @@ If you are running the aarch64 architecture (M1 CPUs), add to your `pom.xml`:
 <dependency>
   <groupId>io.spiffe</groupId>
   <artifactId>grpc-netty-macos-aarch64</artifactId>
-  <version>0.8.17</version>
+  <version>0.9.0</version>
   <scope>runtime</scope>
 </dependency>
 ```
@@ -99,7 +99,7 @@ If you are running the aarch64 architecture (M1 CPUs), add to your `pom.xml`:
 Using Gradle:
 
 ```gradle
-runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos-aarch64', version: '0.8.17'
+runtimeOnly group: 'io.spiffe', name: 'grpc-netty-macos-aarch64', version: '0.9.0'
 ```
 
 *Caveat: not all OpenJDK distributions are aarch64 native, make sure your JDK is also running
@@ -112,7 +112,7 @@ The `java-spiffe-helper` module manages X.509 SVIDs and Bundles in Java Keystore
 
 ### Docker Image
 
-Pull the `java-spiffe-helper` image from `ghcr.io/spiffe/java-spiffe-helper:0.8.17`.
+Pull the `java-spiffe-helper` image from `ghcr.io/spiffe/java-spiffe-helper:0.9.0`.
 
 For more details, see [java-spiffe-helper/README.md](java-spiffe-helper/README.md).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.8.17
+version=0.9.0

--- a/java-spiffe-helper/README.md
+++ b/java-spiffe-helper/README.md
@@ -10,11 +10,11 @@ The Helper automatically gets the SVID updates and stores them in the KeyStore a
 
 On Linux:
 
-`java -jar java-spiffe-helper-0.8.17-linux-x86_64.jar`
+`java -jar java-spiffe-helper-0.9.0-linux-x86_64.jar`
 
 On Mac OS:
 
-`java -jar java-spiffe-helper-0.8.17-osx-x86_64.jar`
+`java -jar java-spiffe-helper-0.9.0-osx-x86_64.jar`
 
 You can run the utility with the `-c` or `--config` option to specify the path to the configuration file. By default, it
 will look for a configuration file named `conf/java-spiffe-helper.properties` in the current working directory.


### PR DESCRIPTION
## Summary 

Bump the project version to `0.9.0`.
Add the `0.9.0` changelog entry.
Update release version references in `README.md` and `java-spiffe-helper/README.md`.